### PR TITLE
regex checkers for line and file

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,23 +237,24 @@ No Parameters
 ## Class org.scalastyle.file.LineRegexChecker - Checks for a matching regex, reports all lines that match the regex.
 This class should not be used for multiple line regular expressions.
 
- * id - regex
+ * id - lineRegex
  * default level - WarningLevel
 
 ### Parameters
 
  * Regex - the pattern to be matched, checker looks for a match on each line
+ * Comment - the comment to be stated upon a match
 
 ## Class org.scalastyle.file.FileRegexChecker - Checks for a matching regex within a file. Will only report if
  a match is made, it does not report match counts or lines numbers. This checker can be used to check for
  multiple line conditions.
 As example, (?m)^\s*\n^\s*\n can be used to look for double blank lines in a file.
 
- * id - regex
+ * id - fileRegex
  * default level - WarningLevel
 
 ### Parameters
 
  * Regex - the pattern to be matched, checker looks for a match within file
-
+ * Comment - the comment to be stated upon a match
 

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -109,3 +109,14 @@ package.object.name.description = Check that package object names match a regula
 package.object.name.regex.label = Regular expression
 package.object.name.regex.description = The package object names must match this regular expression
 
+lineRegex.message = Line regex matched ''{0}''
+lineRegex.label = Line Regex
+lineRegex.description = Check that a regular expression is matched per line
+lineRegex.regex.label = Line Regular expression
+lineRegex.regex.description = The line regular expression has been matched
+
+fileRegex.message = File regex matched ''{0}''
+fileRegex.label = File Regex
+fileRegex.description = Check that a regular expression is matched per file
+fileRegex.regex.label = File Regular expression
+fileRegex.regex.description = The file regular expression has been matched

--- a/src/main/scala/org/scalastyle/file/FileRegexChecker.scala
+++ b/src/main/scala/org/scalastyle/file/FileRegexChecker.scala
@@ -20,15 +20,17 @@ import util.matching.Regex
 import org.scalastyle.{FileError, ScalastyleError, Lines, FileChecker}
 
 class FileRegexChecker extends FileChecker {
-  val errorKey = "multi.line.regex"
+  val errorKey = "fileRegex"
+  private val DefaultComment = ""
   private val DefaultRegEx = ""
 
   def verify(lines: Lines): List[ScalastyleError] = {
+    val comment = getString("comment", DefaultComment)
     val file = (for (line <- lines.lines) yield line.text).mkString("\n")
     val regExpStr = getString("regex", DefaultRegEx)
     val regExp = new Regex(regExpStr)
     val matched = regExp.findFirstIn(file)
 
-    if (matched.isEmpty) Nil else List(FileError())
+    if (matched.isEmpty) Nil else List(FileError(List(comment)))
   }
 }

--- a/src/main/scala/org/scalastyle/file/LineRegexChecker.scala
+++ b/src/main/scala/org/scalastyle/file/LineRegexChecker.scala
@@ -20,10 +20,12 @@ import util.matching.Regex
 import org.scalastyle.{LineError, ScalastyleError, Lines, FileChecker}
 
 class LineRegexChecker extends FileChecker {
-  val errorKey = "regex"
+  val errorKey = "lineRegex"
+  private val DefaultComment = ""
   private val DefaultRegEx = ""
 
   def verify(lines: Lines): List[ScalastyleError] = {
+    val comment = getString("comment", DefaultComment)
     val regExStr = getString("regex", DefaultRegEx)
     val regEx = new Regex(regExStr)
 
@@ -31,7 +33,7 @@ class LineRegexChecker extends FileChecker {
       line <- lines.lines.zipWithIndex;
       if regEx.findFirstIn(line._1.text).isDefined
     ) yield {
-      LineError(line._2 + 1, Nil)
+      LineError(line._2 + 1, List(comment))
     }
 
     errors.toList

--- a/src/test/scala/org/scalastyle/file/FileRegexCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/FileRegexCheckerTest.scala
@@ -20,7 +20,7 @@ import org.scalatest.junit.AssertionsForJUnit
 import org.junit.Test
 
 class FileRegexCheckerTest extends AssertionsForJUnit with CheckerTest {
-  val key = "multi.line.regex"
+  val key = "fileRegex"
   val classUnderTest = classOf[FileRegexChecker]
 
   val source = """
@@ -39,21 +39,23 @@ class foobar {
 
   @Test
   def testMultiLineCheck() {
-    assertErrors(List(fileError()), source, Map("regex" -> "(?m)^\\s*\\}\\n^\\s*\\n^}"))
+    assertErrors(List(fileError(List("no blank line"))), source,
+      Map("regex" -> "(?m)^\\s*\\}\\n^\\s*\\n^}", "comment" -> "no blank line"))
   }
 
   @Test
   def testMultipleMatchesReportsOneFileError() {
-    assertErrors(List(fileError()), source, Map("regex" -> "\\}"))
+    assertErrors(List(fileError(List("no closing"))), source, Map("regex" -> "\\}", "comment" -> "no closing"))
   }
 
   @Test
   def testDoubleBlankLinesCheck() {
-    assertErrors(List(fileError()), source, Map("regex" -> "(?m)^\\s*\\n^\\s*\\n"))
+    assertErrors(List(fileError(List("no double blank line"))), source,
+      Map("regex" -> "(?m)^\\s*\\n^\\s*\\n", "comment" -> "no double blank line"))
   }
 
   @Test
   def testCannotFindMatch() {
-    assertErrors(List(), source, Map("regex" -> "^SHOULD$"))
+    assertErrors(List(), source, Map("regex" -> "^SHOULD$", "comment" -> "no should"))
   }
 }

--- a/src/test/scala/org/scalastyle/file/LineRegexCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/LineRegexCheckerTest.scala
@@ -22,7 +22,7 @@ import org.junit.Test
 // scalastyle:off magic.number
 
 class LineRegexCheckerTest extends AssertionsForJUnit with CheckerTest {
-  val key = "regex"
+  val key = "lineRegex"
   val classUnderTest = classOf[LineRegexChecker]
 
   val source = """
@@ -40,21 +40,24 @@ class foobar {
 
   @Test
   def testSingleMatchCheck() {
-    assertErrors(List(lineError(7)), source, Map("regex" -> "println"))
+    assertErrors(List(lineError(7, List("no println"))), source,
+      Map("regex" -> "println", "comment" -> "no println"))
   }
 
   @Test
   def testSingleMatchWithBoundsCheck() {
-    assertErrors(List(lineError(11)), source, Map("regex" -> "^\\}$"))
+    assertErrors(List(lineError(11, List("no closing at eol"))), source,
+      Map("regex" -> "^\\}$", "comment" -> "no closing at eol"))
   }
 
   @Test
   def testMultipleMatchCheck() {
-    assertErrors(List(lineError(9), lineError(11)), source, Map("regex" -> "\\}"))
+    assertErrors(List(lineError(9, List("no closing")), lineError(11, List("no closing"))),
+      source, Map("regex" -> "\\}", "comment" -> "no closing"))
   }
 
   @Test
   def testCannotFindMatch() {
-    assertErrors(List(), source, Map("regex" -> "^SHOULD$"))
+    assertErrors(List(), source, Map("regex" -> "^SHOULD$", "comment" -> "no should"))
   }
 }


### PR DESCRIPTION
Initial go at adding some code to the project. 

Couple of things 

1) The checker is given broken down lines in the via the verify method. This isn't helpful for the a multiple line regex checker. 
2) In the above conversion, also noticed that trailing blank lines get removed which won't help a particular check for, say, blank lines at the end of a file.
3) The FileRegexChecker just reports a file error. I may, look at changing this if I can think of an acceptable solution to easily report line numbers etc.

Cheers
Graham
