### PR TITLE
Fixing possible address typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This process will be improved in time, but for now, you need to build scalastyle
 
 Then get and build scalastyle-batch
 
-    $ git clone git@github.com:scalastyle/scalastyle-batch.git
+    $ git clone git://github.com/scalastyle/scalastyle-batch.git
     $ cd scalastyle-batch
     $ mvn package # or mvn install
 


### PR DESCRIPTION
The git repo address for the scalastyle-batch repo is for the ssh protocol. I'm guessing it should probably be the read only http git protocol instead.
