### PR TITLE
Add a checker which forbids some tokens by regular expression.

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -118,4 +118,9 @@
  <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
  <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
  <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
 </scalastyle>

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -105,4 +105,9 @@
     <checker class="org.scalastyle.scalariform.VarFieldChecker" id="var.field" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.VarLocalChecker" id="var.local" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.RedundantIfChecker" id="if.redundant" defaultLevel="warning"/>
+    <checker class="org.scalastyle.scalariform.TokenChecker" id="token" defaultLevel="warning" >
+        <parameters>
+            <parameter name="regex" type="string" default="^$" />
+        </parameters>
+    </checker>
 </scalastyle-definition>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -230,4 +230,17 @@ is considered to be a magic number.
  </example-configuration>
  </check>
 
+ <check id="token">
+ <example-configuration>
+ <![CDATA[
+    <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+      <parameters>
+        <parameter name="regex">^[ai]sInstanceOf$</parameter>
+      </parameters>
+      <customMessage>Avoid casting.</customMessage>
+    </check>
+ ]]>
+ </example-configuration>
+ </check>
+
 </scalastyle-documentation>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -188,3 +188,9 @@ while.description = Checks that while is not used
 if.redundant.message = Eliminate redundant if expressions where both branches return constant booleans
 if.redundant.label = No redundant if expressions
 if.redundant.description = Checks that if expressions are not redundant, i.e. easily replaced by a variant of the condition
+
+token.message = Regular expression matched ''{0}'' in a token
+token.label = Regular expression in a token
+token.description = Checks that a regular expression cannot be matched in a token, if found reports this
+token.regex.label = Regular expression
+token.regex.description = Standard Scala regular expression syntax

--- a/src/main/scala/org/scalastyle/scalariform/TokenChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/TokenChecker.scala
@@ -1,0 +1,47 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import java.lang.reflect.Constructor
+import scalariform.parser.CompilationUnit
+import _root_.scalariform.lexer.Tokens._
+import org.scalastyle.ScalariformChecker
+import org.scalastyle._
+import org.scalastyle.FileSpec
+import _root_.scalariform.parser._
+import _root_.scalariform.lexer.Token
+import util.matching.Regex
+
+class TokenChecker extends CombinedChecker {
+  import VisitorHelper._
+  val errorKey = "token"
+  private val DefaultRegEx = "^$"
+    
+  def verify(ast: CombinedAst): List[ScalastyleError] = {
+    val regExpStr = getString("regex", DefaultRegEx)
+    val regExp = new Regex(regExpStr)
+
+    val it = for (
+      t <- ast.compilationUnit.tokens
+      if t.tokenType == VARID && regExp.findFirstIn(t.text) != None
+   ) yield {
+      PositionError(t.offset)
+    }
+
+    it.toList
+  }
+}

--- a/src/test/scala/org/scalastyle/scalariform/TokenCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/TokenCheckerTest.scala
@@ -1,0 +1,56 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.scalatest.junit.AssertionsForJUnit
+import org.junit.Test
+import org.scalastyle.file.CheckerTest
+
+class TokenCheckerTest extends AssertionsForJUnit with CheckerTest {
+  protected val classUnderTest = classOf[TokenChecker]
+  protected val key = "token"
+
+  @Test def testErrors1 {
+    val source = """
+object foo {
+  def bar(x: Any) = x.asInstanceOf[Int]
+}"""
+
+    assertErrors(List(columnError(3, 22)), source, Map("regex" -> "^[ai]sInstanceOf$"))
+  }
+
+  @Test def testErrors2 {
+    val source = """
+import collection.mutable._
+object foo {
+  def bar(x: Any) = new ArrayList[Int]()
+}"""
+
+    assertErrors(List(columnError(2, 18), columnError(4, 24)), source, Map("regex" -> "^ArrayList|ArrayBuffer|mutable$"))
+  }
+
+  @Test def testOk {
+    val source = """
+object foo {
+  /** asInstanceOf[Int] is not used */
+  def bar(x: Any) = 1
+}"""
+
+    assertErrors(List(), source, Map("regex" -> "^[ai]sInstanceOf$"))
+  }
+
+}


### PR DESCRIPTION
This is similar to the RegexChecker, except it's only for tokens and
per token. This checker provides a quick way to forbid some particular
construct such as isInstanceOf. When using the RegexChecer for this,
students were complaining that the style checker was reporting
warnings in commented code.
