### PR TITLE
fixes issue #34: include _= suffix mutator MethodNamesChecker

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -103,7 +103,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*(_=)?$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">

--- a/lib/scalastyle_scala_config.xml
+++ b/lib/scalastyle_scala_config.xml
@@ -103,7 +103,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*(_=)?$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">

--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -103,7 +103,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*(_=)?$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -90,7 +90,7 @@
     </checker>
     <checker class="org.scalastyle.scalariform.MethodNamesChecker" id="method.name" defaultLevel="warning" >
         <parameters>
-            <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*$" />
+            <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*(_=)?$" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" id="number.of.methods" defaultLevel="warning" >

--- a/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
@@ -87,7 +87,7 @@ class PackageObjectNamesChecker extends ScalariformChecker {
 }
 
 class MethodNamesChecker extends ScalariformChecker {
-  val DefaultRegex = "^[a-z][A-Za-z0-9]*$"
+  val DefaultRegex = "^[a-z][A-Za-z0-9]*(_=)?$"
   val errorKey = "method.name"
 
   def verify(ast: CompilationUnit): List[ScalastyleError] = {

--- a/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
@@ -157,10 +157,11 @@ class Foobar {
   def foo() = 1
   def +() = 1
 //  def foo+() = 1
+  def setting_=(s: Boolean) {}
 }
 """;
 
-    assertErrors(List(columnError(6, 6, List("^[a-z][A-Za-z0-9]*$"))), source)
+    assertErrors(List(columnError(6, 6, List("^[a-z][A-Za-z0-9]*(_=)?$"))), source)
   }
 
   @Test def testNonDefault() {


### PR DESCRIPTION
I hope I didn't forget anything. For this I did

```
grep -rl MethodNamesChecker
```

and looked through all these files. I also added such a mutator example to the tests, which succeeded via

```
mvn test
```
