### PR TITLE
Add rule to catch usage of ??? operator

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -113,4 +113,5 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true" />
 </scalastyle>

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -132,4 +132,5 @@
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.ImportGroupingChecker" id="import.grouping" defaultLevel="warning"/>
+    <checker class="org.scalastyle.scalariform.NotImplementedErrorUsage" id="not.implemented.error.usage" defaultLevel="warning"/>
 </scalastyle-definition>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -353,5 +353,16 @@ is considered to be a magic number.
  ]]>
  </example-configuration>
  </check>
+ 
+ <check id="not.implemented.error.usage">
+ <justification>
+  The ??? operator denotes that an implementation is missing. This rule helps to avoid potential runtime errors because of not implemented code.
+ </justification>
+ <example-configuration>
+ <![CDATA[
+    <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true" />
+ ]]>
+ </example-configuration>
+ </check>
 
 </scalastyle-documentation>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -234,3 +234,7 @@ multiple.string.literals.ignoreRegex.description = Regular expression to ignore
 import.grouping.message = Imports should be grouped together 
 import.grouping.label = Group imports
 import.grouping.description = Checks that imports are grouped together, not throughout the file
+
+not.implemented.error.usage.message = Usage of ??? operator
+not.implemented.error.usage.label = Usage of ??? operator
+not.implemented.error.usage.description = The ??? operator denotes that an implementation is missing. This rule helps to avoid potential runtime errors because of not implemented code.

--- a/src/main/scala/org/scalastyle/scalariform/NotImplementedErrorUsage.scala
+++ b/src/main/scala/org/scalastyle/scalariform/NotImplementedErrorUsage.scala
@@ -1,0 +1,33 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.scalastyle.{ ScalastyleError, ScalariformChecker, PositionError }
+
+import scalariform.lexer.Tokens.VARID
+import scalariform.parser.CompilationUnit
+
+class NotImplementedErrorUsage extends ScalariformChecker {
+
+  val errorKey = "not.implemented.error.usage"
+
+  def verify(ast: CompilationUnit): List[ScalastyleError] =
+    for {
+      t <- ast.tokens
+      if t.tokenType == VARID && t.text == "???"
+    } yield PositionError(t.offset)
+}

--- a/src/test/scala/org/scalastyle/scalariform/NotImplementedErrorUsageTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NotImplementedErrorUsageTest.scala
@@ -1,0 +1,49 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalastyle.file.CheckerTest
+import org.junit.Test
+
+// scalastyle:off magic.number
+
+class NotImplementedErrorUsageTest extends AssertionsForJUnit with CheckerTest {
+
+  val key = "not.implemented.error.usage"
+  val classUnderTest = classOf[NotImplementedErrorUsage]
+
+  @Test
+  def noErrors() {
+    val source = """
+class X {
+  val x = 0
+}
+      """
+    assertErrors(Nil, source)
+  }
+
+  @Test
+  def notImplementedErrorFound() {
+    val source = """
+class X {
+  val x = ???
+}
+      """
+    assertErrors(List(columnError(3, 10)), source)
+  }
+}


### PR DESCRIPTION
Fixes #36

---

The only problem with this one is that it also shows warnings on user defined ??? symbols. But for 2.10 this shouldn't be a problem because ??? is automatically imported in Predef, thus no need/not a good a idea to redefine ???
