### PR TITLE
Update BlockImportChecker

### DIFF
--- a/src/test/scala/org/scalastyle/scalariform/BlockImportCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/BlockImportCheckerTest.scala
@@ -74,4 +74,28 @@ import scala.collection.mutable.{Buffer, ArrayBuffer}
       """
     assertErrors(List(columnError(2, 7)), source)
   }
+
+  @Test
+  def wildcardImportAfterRenameImportsIsNoBlockImport() {
+    val source = """
+import scala.collection.mutable.{Buffer => MB, ArrayBuffer => _, _}
+      """
+    assertErrors(Nil, source)
+  }
+
+  @Test
+  def wildcardImportAfterNormalImportAndRenameImportIsBlockImport() {
+    val source = """
+import scala.collection.mutable.{Buffer => MB, ArrayBuffer, _}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def wildcardImportAfterNormalImportIsBlockImport() {
+    val source = """
+import scala.collection.mutable.{ArrayBuffer, _}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
 }


### PR DESCRIPTION
Before, the block import checker did mark imports of the form

  import foo.bar.{baz => _, _}

and

  import foo.bar.{baz => buz, _}

as an error, which is wrong because there is no other way to write
such imports in Scala.
