### PR TITLE
Add more info to cyclomatic complexity message.

### DIFF
--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -121,7 +121,7 @@ number.of.types.description = Checks that there are not too many types declared 
 number.of.types.maxTypes.label = Maximum Number
 number.of.types.maxTypes.description = Maximum number of types to allow
 
-cyclomatic.complexity.message = Cyclomatic complexity exceeds {0}
+cyclomatic.complexity.message = Cyclomatic complexity of {0} exceeds max of {1}
 cyclomatic.complexity.label = Cyclomatic complexity
 cyclomatic.complexity.description = Checks that the cyclomatic complexity of a method does exceed a value
 cyclomatic.complexity.maximum.label = Maximum

--- a/src/main/scala/org/scalastyle/scalariform/AbstractMethodChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/AbstractMethodChecker.scala
@@ -73,7 +73,7 @@ object VisitorHelper {
 
 abstract class AbstractMethodChecker extends ScalariformChecker {
   type ListType = List[BaseClazz[_ <: AstNode]]
-  protected def params(): List[String] = List()
+  protected def params(t: BaseClazz[AstNode]): List[String] = List()
 
   class BaseClazz[+T <: AstNode](val t: T, val position: Option[Int], val subs: ListType) extends Clazz[T] {
     def is(fn: T => Boolean): Boolean = false
@@ -85,14 +85,12 @@ abstract class AbstractMethodChecker extends ScalariformChecker {
   }
 
   final def verify(ast: CompilationUnit): List[ScalastyleError] = {
-    val pList = params()
-
     val it = for (
       t <- localvisit(ast.immediateChildren(0));
       f <- traverse(t);
       if (matches(f))
     ) yield {
-      PositionError(f.position.get, pList)
+      PositionError(f.position.get, params(f))
     }
 
     it.toList

--- a/src/main/scala/org/scalastyle/scalariform/CyclomaticComplexityChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/CyclomaticComplexityChecker.scala
@@ -32,15 +32,18 @@ class CyclomaticComplexityChecker extends AbstractMethodChecker {
   private lazy val maximum = getInt("maximum", DefaultMaximum)
   private val tokens = Set(IF, CASE, WHILE, DO, FOR)
 
-  override def params(): List[String] = List("" + maximum)
+  override def params(t: BaseClazz[AstNode]): List[String] = List("" + cyclomaticComplexity(t), "" + maximum)
 
   def matches(t: BaseClazz[AstNode]): Boolean = {
-    matchFunDefOrDcl(t, cyclomaticComplexity(maximum) _)
+    cyclomaticComplexity(t) > maximum
   }
 
   private def isLogicalOrAnd(t: Token) = t.tokenType == VARID && (t.text == "&&" || t.text == "||")
 
-  private def cyclomaticComplexity(maximum: Int)(t: FunDefOrDcl): Boolean = {
-    t.tokens.count(t => tokens.contains(t.tokenType) || isLogicalOrAnd(t)) + 1 > maximum
+  def cyclomaticComplexity(t: BaseClazz[AstNode]): Int = {
+    t match {
+      case f: FunDefOrDclClazz => f.t.tokens.count(t => tokens.contains(t.tokenType) || isLogicalOrAnd(t)) + 1
+      case _ => 0
+    }
   }
 }

--- a/src/main/scala/org/scalastyle/scalariform/NumberOfMethodsInTypeChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/NumberOfMethodsInTypeChecker.scala
@@ -22,7 +22,7 @@ class NumberOfMethodsInTypeChecker extends AbstractMethodChecker {
   val errorKey = "number.of.methods"
   val DefaultMaxMethods = 30
 
-  override def params(): List[String] = List("" + getInt("maxMethods", DefaultMaxMethods))
+  override def params(t: BaseClazz[AstNode]): List[String] = List("" + getInt("maxMethods", DefaultMaxMethods))
 
   def matches(t: BaseClazz[AstNode]): Boolean = {
     val maxMethods = getInt("maxMethods", DefaultMaxMethods)

--- a/src/test/scala/org/scalastyle/scalariform/CyclomaticComplexityCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/CyclomaticComplexityCheckerTest.scala
@@ -77,6 +77,6 @@ class Foobar {
 }
 """;
 
-    assertErrors(List(columnError(5, 6, List("11")), columnError(24, 6, List("11"))), source, Map("maximum" -> "11"))
+    assertErrors(List(columnError(5, 6, List("12", "11")), columnError(24, 6, List("12", "11"))), source, Map("maximum" -> "11"))
   }
 }


### PR DESCRIPTION
The old message just gave the max allowed cyclomatic complexity. This
  made it difficult to figure out how much a method needed to be broken
  up without rerunning scalastyle after each refactor to check how much
  the complexity had changed.

The new message gives the current complexity and the max complexity.

This change requires that AbstractMethodChecker.params be computed
  dynamically based on the BaseClazz[AstNode] being matched. In
  CyclomaticComplexityChecker, the calculation of the complexity is
  moved to a separate method so that it can be used to calculate the
  params.

A similar change can be done for NumberOfMethodsInTypeChecker, but it's
  much easier to find the number of methods in a class than the
  cyclomatic complexity of a method, so the change isn't as beneficial.
  It should be easy to do if there is desire though.
