### PR TITLE
BlankLineBetweenDefinitionChecker

### DIFF
--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -175,6 +175,12 @@ newline.at.eof.message = File must end with newline character
 newline.at.eof.label = Newline at EOF
 newline.at.eof.description = Checks that a file ends with a newline character
 
+blankline.between.definition.message = Insert blank line between class/object/method definition
+blankline.between.definition.description =  Checks that a blank line between class/object/method definition
+blankline.between.definition.label = Blank line between class/object/method definition
+blankline.between.definition.noBlankLineAfterClassAllowed.message = No blank line after class/object definition allowed
+blankline.between.definition.noBlankLineAfterClassAllowed.label = No blank line after class/object definition allowed
+
 no.newline.at.eof.message = File must not end with newline character
 no.newline.at.eof.label = No Newline at EOF
 no.newline.at.eof.description = Checks that a file does not end with a newline character

--- a/src/main/scala/org/scalastyle/scalariform/BlankLineBetweenDefinitionChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/BlankLineBetweenDefinitionChecker.scala
@@ -1,0 +1,168 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import _root_.scalariform.parser._
+import org.scalastyle.{CombinedChecker, ScalastyleError, CombinedAst, Lines, PositionError}
+import org.scalastyle.scalariform.VisitorHelper.{TreeVisit, visit}
+import scala.annotation.tailrec
+
+/**
+ * According to the Effective Scala "http://twitter.github.io/effectivescala/index.html#Formatting-Whitespace"
+ * they suggest, Use one blank line between method, class, and object definitions.
+ *
+ * this checker detects class/object/method where not contains one blank line between definition.
+ *
+ * Configuration.
+ * to allow no blank line between class/object and method, like below
+ *
+ * class Foo{
+ * def bar = ...
+ * }
+ *
+ * to allow this option, set parameter "true" at configuration xml
+ * by default its set to "false"
+ *
+ * <parameters>
+ * <parameter name="NoBlankAfterClassAllowed">true</parameter>
+ * </parameters>
+ */
+class BlankLineBetweenDefinitionChecker extends CombinedChecker {
+  val errorKey = "blankline.between.definition"
+
+  val paramNoBlankAfterClassAllowed = "NoBlankAfterClassAllowed"
+  val paramNoBlankAfterClassAllowedDefValue = false
+
+  case class TmplClazz(t: TmplDef, subs: List[TmplClazz]) extends TreeVisit[TmplClazz]
+
+  private def map(t: TmplDef): List[TmplClazz] = List(TmplClazz(t, visit(map)(t.templateBodyOption)))
+
+  final def verify(ast: CombinedAst): List[ScalastyleError] = {
+    val noBlankAfterClassAllowed = getBoolean(paramNoBlankAfterClassAllowed, paramNoBlankAfterClassAllowedDefValue)
+
+    val cu = ast.compilationUnit
+    val clazz = visit[TmplDef, TmplClazz](map)(cu.immediateChildren(0));
+
+    clazz.map(verifyClazz(_, ast.lines, noBlankAfterClassAllowed)).flatten
+  }
+
+  private def verifyClazz(t: TmplClazz, lines: Lines,
+                          noBlankAfterClassAllowed: Boolean): List[ScalastyleError] = t.t.templateBodyOption match {
+    case Some(b)
+    => verifyBody(b, lines, noBlankAfterClassAllowed) ::: t.subs.map(verifyClazz(_, lines, noBlankAfterClassAllowed)).flatten
+    case None => Nil
+  }
+
+  private def verifyBody(b: TemplateBody, lines: Lines,
+                         noBlankAfterClassAllowed: Boolean): List[ScalastyleError] = {
+    val ss = b.statSeq
+    val head = lines.toLineColumn(b.firstToken.offset).get.line
+
+    val otherStats = for (
+      (t, Some(s)) <- ss.otherStats
+    ) yield s
+
+    val stats = ss.firstStatOpt match {
+      case Some(s) => s :: otherStats
+      case None => otherStats
+    }
+
+    val statsWithCodeRange = for (
+      s <- stats;
+      r <- toCodeRanges(s, lines)
+    ) yield (s, r)
+
+    val defOrDclsWithCodeRange = statsWithCodeRange.filter {
+      case (x: FullDefOrDcl, _) if x.defOrDcl.isInstanceOf[FunDefOrDcl] || x.defOrDcl.isInstanceOf[TmplDef] => true
+      case _ => false
+    }
+
+    val results = for (
+      d <- defOrDclsWithCodeRange;
+      a <- check(d, statsWithCodeRange, lines, head, noBlankAfterClassAllowed)
+    ) yield a
+
+    results
+  }
+
+  private def check(t: (Stat, (Int, Int)), cs: List[(Stat, (Int, Int))],
+                    lines: Lines, head: Int, noBlankAfterClassAllowed: Boolean): Option[ScalastyleError] = {
+    val (funDef, (lineNumber, _)) = t
+
+    val exprList = for (c <- cs if c._2._2 != lineNumber) yield c._2._2
+    val exprListWithClassDef = if (noBlankAfterClassAllowed) {
+      exprList
+    } else {
+      head :: exprList
+    }
+
+    funDef.firstTokenOption.flatMap(t => {
+      if (checkIsBlankLine(lineNumber, lines, exprListWithClassDef)) {
+        None
+      } else {
+        Some(PositionError(t.offset))
+      }
+    })
+  }
+
+  final val BlockCommentStart = """/\*""".r
+  final val BlockCommentFinish = """\*/""".r
+
+  final val LineNumber2ArrayAdjuster = 1
+
+  @tailrec
+  private def checkIsBlankLine(lineNumber: Int, source: Lines, endOfExprList: List[Int]): Boolean = {
+    if (!endOfExprList.contains(lineNumber)) {
+      val skip = skipComment(lineNumber, source)
+      if (skip == lineNumber) true else checkIsBlankLine(skip, source, endOfExprList)
+    } else {
+      false
+    }
+  }
+
+  private def skipComment(lineNumber: Int, source: Lines): Int = {
+    val text = source.lines(lineNumber - LineNumber2ArrayAdjuster).text
+    if (text.length != 0) {
+      execSkipComment(lineNumber, source, 0)
+    } else {
+      lineNumber
+    }
+  }
+
+  @tailrec
+  private def execSkipComment(lineNumber: Int, source: Lines, blockCommentLevel: Int): Int = {
+    val text = source.lines(lineNumber - LineNumber2ArrayAdjuster).text
+    val diff = blockCommentLevel + BlockCommentFinish.findAllIn(text).length - BlockCommentStart.findAllIn(text).length
+    if (diff == 0) {
+      lineNumber - 1
+    } else {
+      execSkipComment(lineNumber - 1, source, diff)
+    }
+  }
+
+  private def toCodeRanges(stats: Stat, lines: Lines): Option[(Int, Int)] = {
+    val offsets = (stats.firstTokenOption, stats.lastTokenOption) match {
+      case (Some(s), Some(e)) => Some((s.offset, e.offset))
+      case _ => None
+    }
+
+    for ((s, e) <- offsets;
+         sLine <- lines.toLineColumn(s);
+         eLine <- lines.toLineColumn(e)
+    ) yield (sLine.line, eLine.line)
+  }
+}

--- a/src/test/scala/org/scalastyle/scalariform/BlankLineBetweenDefinitionCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/BlankLineBetweenDefinitionCheckerTest.scala
@@ -1,0 +1,253 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalastyle.file.CheckerTest
+import org.junit.Test
+
+// scalastyle:off magic.number multiple.string.literals
+
+class BlankLineBetweenDefinitionCheckerTest extends AssertionsForJUnit with CheckerTest {
+  val key = "blankline.between.definition"
+  val classUnderTest = classOf[BlankLineBetweenDefinitionChecker]
+
+  @Test def testMethodDefinedAfterEmptyLine(): Unit = {
+    val code = """
+package foobar
+object Foo
+{
+
+  def bar() = Nil;
+}
+               """.stripMargin
+
+    assertErrors(List(), code)
+  }
+
+  @Test def testMethodDefDefinedAfterValidCode(): Unit = {
+    val code = """
+package foobar
+object Foo{
+  val foo = 1
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(columnError(5, 2)), code)
+
+  }
+
+  @Test def testMethodDefinedWithSemiColon(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  def bar() = Nil; def foo() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(), code)
+  }
+
+  @Test def testMethodDefinedAfterEmptyLineWithSingleComment(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  // single-line comment
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(), code)
+  }
+
+  @Test def testMethodDefinedAfterEmptyLineWithBlockComment(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  /*
+    block comment
+  */
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(), code)
+  }
+
+  @Test def testNestedComments(): Unit = {
+    val code = """
+package foobar
+object Foo{
+  /*
+
+      // nested
+    /*
+
+    /*
+      // nested
+    */
+    /*  */
+  */ */ /* */
+  /*   */
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(columnError(15, 2)), code)
+  }
+
+  @Test def testMethodDefinedAfterNonsenseComments(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  /*
+
+    block comment
+
+  */
+  def bar() = Nil
+
+  /*
+    block comment
+  */ def foo() = Nil
+
+  /* block comment */ def foobar() = Nil
+  /* block comment */ def barfoo() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(columnError(17, 22)), code)
+
+  }
+
+  @Test def testMethodDefinedAfterValidCodeWithSingleComment(): Unit = {
+    val code = """
+package foobar
+object Foo{
+  val foo = 1
+  // single-line comment
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(columnError(6, 2)), code)
+  }
+
+  @Test def testMethodDefinedAfterValidCodeWithBlockComment(): Unit = {
+    val code = """
+package foobar
+object Foo{
+  val foo = 1
+  /*
+    block comment
+  */
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(columnError(8, 2)), code)
+
+  }
+
+  @Test def testMethodDefinedInInnerClass(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  class Bar{
+
+    def foobar() = Nil
+  }
+}
+               """.stripMargin
+
+    assertErrors(List(), code)
+  }
+
+  @Test def testMethodDefinedInInnerClassAfterValidCode(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  object Bar{
+    def foobar() = Nil
+  }
+}
+               """.stripMargin
+
+    assertErrors(List(columnError(6, 4)), code)
+  }
+
+  @Test def testMultipleClass(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  def foobar() = Nil
+}
+
+class Bar {
+  def foobar() = Nil
+}
+               """.stripMargin
+    assertErrors(List(columnError(9, 2)), code)
+  }
+
+  @Test def testComplicatedClassDefinition(): Unit = {
+    val code = """
+package foobar
+object Foo{
+
+  def foobar() = Nil
+
+  class A {
+
+    class B {
+      // bbbb
+      def b() = Nil
+
+      object C {
+
+        def c() = Nil
+
+        class D {
+          def d() = Nil
+        }
+      }
+    }
+  }
+}
+               """.stripMargin
+    assertErrors(List(columnError(11, 6), columnError(18, 10)), code)
+  }
+
+  @Test def testAllowNoBlankAfterClass(): Unit = {
+    val code = """
+package foobar
+class Foo {
+  def bar() = Nil
+}
+               """.stripMargin
+
+    assertErrors(List(), code, Map("NoBlankAfterClassAllowed" -> "true"))
+  }
+}


### PR DESCRIPTION
This checker detects the class/object/trait/method definition has no blank line above.
[Effective Scala](http://twitter.github.io/effectivescala/index.html#Formatting-Whitespace) suggests "Use blank line between between method, class, and object definitions."

For example.
this method definition will not allowed by checker

```
def foo() = ...
def bar() = ...
```

to remove warnings we have to write like this,

```
def foo() = ...

def bar() = ... 
```
