### PR TITLE
Add NoWhitespaceBeforeColonChecker and WhitespaceAfterColonChecker

### DIFF
--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -137,8 +137,12 @@
     <checker class="org.scalastyle.scalariform.ProcedureDeclarationChecker" id="procedure.declaration" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.NoWhitespaceBeforeColonChecker" id="no.whitespace.before.colon" defaultLevel="warning">
       <parameters>
-          <parameter name="lineBreakAllowed" type="boolean" default="true" />
+          <parameter name="lineBreakAllowed" type="boolean" default="false" />
       </parameters>
     </checker>
-    <checker class="org.scalastyle.scalariform.WhitespaceAfterColonChecker" id="whitespace.after.colon" defaultLevel="warning"/>
+    <checker class="org.scalastyle.scalariform.WhitespaceAfterColonChecker" id="whitespace.after.colon" defaultLevel="warning">
+      <parameters>
+          <parameter name="lineBreakAllowed" type="boolean" default="false" />
+      </parameters>
+    </checker>
 </scalastyle-definition>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -256,3 +256,5 @@ no.whitespace.before.colon.lineBreakAllowed.description = "Allow break line befo
 whitespace.after.colon.message = Insert a whitespace after colon
 whitespace.after.colon.label = Insert a whitespace after colon
 whitespace.after.colon.description = Checks that there are one whitespace after colon
+whitespace.after.colon.lineBreakAllowed.label = "Allow break line after colon"
+whitespace.after.colon.lineBreakAllowed.description = "Allow break line after colon, or not"

--- a/src/main/scala/org/scalastyle/scalariform/WhitespaceColonChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/WhitespaceColonChecker.scala
@@ -16,18 +16,14 @@
 
 package org.scalastyle.scalariform
 
-import org.scalastyle._
-
-import _root_.scalariform.lexer.Tokens.COLON
-import org.scalastyle.scalariform.VisitorHelper._
-import _root_.scalariform.parser.PatDefOrDcl
-import _root_.scalariform.parser.FunDefOrDcl
-import _root_.scalariform.parser.CasePattern
-import _root_.scalariform.lexer.Token
-import _root_.scalariform.parser.TmplDef
-import _root_.scalariform.parser.CompilationUnit
+import scalariform.lexer.Token
+import scalariform.parser.{FunDefOrDcl, PatDefOrDcl, TmplDef, CasePattern}
 import scala.Some
+import org.scalastyle._
+import org.scalastyle.Lines
 import org.scalastyle.PositionError
+import org.scalastyle.scalariform.VisitorHelper.visit
+import _root_.scalariform.lexer.Tokens.COLON
 
 /**
  * Check each tokens in type annotations
@@ -137,7 +133,16 @@ class NoWhitespaceBeforeColonChecker extends ColonChecker {
  */
 class WhitespaceAfterColonChecker extends ColonChecker {
   val errorKey = "whitespace.after.colon"
+  val paramLineBreakAllowed = "lineBreakAllowed"
 
-  def localMatcher(prev: Token, current: Token, next: Token, lines: Lines) =
-    isSingleColonToken(current, next) && charsBetweenTokens(current, next) != 1
+  def localMatcher(prev: Token, current: Token, next: Token, lines: Lines) = {
+    val allowLineBreak = getBoolean(paramLineBreakAllowed, false)
+
+    allowLineBreak match {
+      case true =>
+        isSingleColonToken(current, next) && !(charsBetweenTokens(current, next) == 1 || linesBetweenTokens(lines, current, next) == 1)
+      case false =>
+        isSingleColonToken(current, next) && !(charsBetweenTokens(current, next) == 1)
+    }
+  }
 }

--- a/src/test/scala/org/scalastyle/scalariform/WhitespaceColonCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/WhitespaceColonCheckerTest.scala
@@ -19,7 +19,6 @@ package org.scalastyle.scalariform
 import org.scalastyle.file.CheckerTest
 import org.scalatest.junit.AssertionsForJUnit
 import org.junit.Test
-import org.scalastyle.ColumnError
 
 // scalastyle:off magic.number
 
@@ -203,6 +202,9 @@ class Foobar() {
     val l = 1 :: List(2, 3)
   }
   def bar: Unit { }
+  def baz(x: Int)(implicit y: Int): Int = x
+  def foobar[T]: Int = 1
+  def foobaz[T](x: Int): Int = 1
 }
                  """;
 
@@ -218,11 +220,15 @@ class Foobar() {
     val i :Int = 1
     val l = 1 :: List(2, 3)
   }
-  def bar :Unit { }
+  def bar: Unit { }
+  def baz(x:Int)(implicit y:Int):Int = x
+  def foobar[T]:Int = 1
+  def foobaz[T](x:Int):Int = 1
 }
                  """;
 
-    assertErrors(List(columnError(3, 11), columnError(4, 15), columnError(6, 10), columnError(9, 10)), source)
+    assertErrors(List(columnError(3, 11), columnError(4, 15), columnError(6, 10), columnError(10, 11),
+      columnError(10, 27), columnError(10, 32), columnError(11, 15), columnError(12, 17), columnError(12, 22)), source)
   }
 
   @Test def testCaseStatementOK() {
@@ -261,5 +267,45 @@ class Foobar() {
                  """;
 
     assertErrors(List(columnError(8, 13), columnError(9, 13)), source)
+  }
+
+  @Test def testLineBreakAllowed() {
+    val source = """
+case class Something()
+case class Anything()
+
+class Foobar() {
+  def bar(
+    veryLongArgumentFoo: Int,
+    veryLongArgumentBar: Int):
+    Unit {
+      val a: Int = 0
+      val b:
+      Int = 0
+  }
+}
+                 """;
+
+    assertErrors(List(), source, Map("lineBreakAllowed" -> "true"))
+  }
+
+  @Test def testLineBreakNotAllowed() {
+    val source = """
+case class Something()
+case class Anything()
+
+class Foobar() {
+  def bar(
+    veryLongArgumentFoo: Int,
+    veryLongArgumentBar: Int):
+    Unit {
+      val a: Int = 0
+      val b:
+      Int = 0
+  }
+}
+                 """;
+
+    assertErrors(List(columnError(8, 29), columnError(11, 11)), source, Map("lineBreakAllowed" -> "false"))
   }
 }


### PR DESCRIPTION
These checkers assist to be no whitespace before colon, and only one whitespace after colon for [Scala Style Guide](http://docs.scala-lang.org/style/types.html).
The checker covers following statements
#### Value and Variable

```
// OK
val i: Int = 1
// NG
val j :Int = 1
```
#### Function

```
// OK
def foo(x: Int, y: Int): Unit { }
def bar: Unit { }
// NG
def foo(x :Int, y :Int) :Unit { }
def bar: Unit { }    
```
#### Class

```
// OK
class Foobar(a: Int, b: Int) { }
// NG
class Foobar(a :Int, b :Int) { }
```
#### Case

```
// OK
val l = List(Dog, Dog, Cat, Dog, Cat).map{
  case i: Dog => 2
  case s: Cat => 1
  case _ => 0
}
// NG
val l = List(Dog, Dog, Cat, Dog, Cat).map{
  case i :Dog => 2
  case s :Cat => 1
  case _ => 0
}
```

This style is adopted by most of the Scala standard library.
