### PR TITLE
SimpleExprWithBraceChecker

### DIFF
--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -80,6 +80,7 @@
     <checker class="org.scalastyle.scalariform.SimpleExprWithBraceChecker" id="simple.expression.with.brace" defaultLevel="warning" >
         <parameters>
             <parameter name="targetTokens" type="string" default="" />
+            <parameter name="nestedAllowed" type="boolean" default="false" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.IfBraceChecker" id="if.brace" defaultLevel="warning" >

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -140,6 +140,8 @@ simple.expression.with.brace.label = Simple expression with brace
 simple.expression.with.brace.description = Avoid using braces for simple expression
 simple.expression.with.brace.targetTokens.label = Target tokens to check
 simple.expression.with.brace.targetTokens.description =  Target tokens are checked by checker
+simple.expression.with.brace.nestedAllowed.label = Allow nested single expression
+simple.expression.with.brace.nestedAllowed.description = Nested single expressions are allowed by checker
 
 if.brace.message = If block needs braces
 if.brace.label = If block braces

--- a/src/test/scala/org/scalastyle/scalariform/SimpleExprWithBraceCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SimpleExprWithBraceCheckerTest.scala
@@ -323,4 +323,24 @@ class A {
 """.stripMargin
     assertErrors(List(), code, Map("targetTokens" -> "case"))
   }
+
+  @Test def testNestedExpressionAllowed(): Unit = {
+    val code = """
+class A {
+  def a() = {
+    List(1,2,3).map(_ + 1).filter(_ == 1)
+  }
+}""".stripMargin
+    assertErrors(List(), code, Map("targetTokens" -> "def", "nestedAllowed" -> "true"))
+  }
+
+  @Test def testNestedExpressionNotAllowed(): Unit = {
+    val code = """
+class A {
+  def a() = {
+    List(1,2,3).map(_ + 1).filter(_ == 1)
+  }
+}""".stripMargin
+    assertErrors(List(columnError(3, 12)), code, Map("targetTokens" -> "def", "nestedAllowed" -> "false"))
+  }
 }


### PR DESCRIPTION
#### About this checker

This checker detects the brace contains a simple expression.

[Effective Scala](http://twitter.github.io/effectivescala/#Formatting-Braces) suggests "Braces are used to create compound expressions, where the value of the compound expression is the last expression in the list. Avoid using braces for simple expressions".

We define `a simple expression` as a single expression.

For example,
the checker allows

```
def foo(x: Int) = x * 2
```

but, does not allow

```
def foo(x: Int) = {
  x * 2
}
```
#### How to configure

By default configuration, the checker detects nothing.
To use this rule, you need to specify the target tokens by using "TargetToken" parameter in a config file.
Available tokens are "def,val,var,if,for,while,do,case"

Here is an example configuration,

```
<checker class="org.scalastyle.scalariform.SimpleExprWithBraceChecker">
    <parameters>
        <parameter name="targetToken">if, def, val, var</parameter>
    </parameter>
<checker>
```
