### PR TITLE
Added Indentation Checker

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -286,3 +286,8 @@ ensure.single.space.before.token.description = "Ensure single space before certa
 ensure.single.space.before.token.tokens.label = "Tokens"
 ensure.single.space.before.token.tokens.description = "Comma separated list, default value none"
 
+indentation.message = Use correct indentation
+indentation.label = Use correct indentation
+indentation.description = Checks that lines are indented by a multiple of the tab size
+indentation.tabSize.label = "Tab size"
+indentation.tabSize.description = "Number of characters that a tab represents"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -144,4 +144,10 @@
     <checker class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" id="disallow.space.before.token" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" id="ensure.single.space.after.token" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" id="ensure.single.space.before.token" defaultLevel="warning"/>
+
+    <checker class="org.scalastyle.file.IndentationChecker" id="indentation" defaultLevel="warning">
+        <parameters>
+            <parameter name="tabSize" type="integer" default="2" />
+        </parameters>
+    </checker>
 </scalastyle-definition>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -261,3 +261,7 @@ space.after.comment.start.description = Checks a space after the start and befor
 scaladoc.message = Missing or badly formed ScalaDoc: {0}
 scaladoc.label = Missing or badly formed ScalaDoc: {0}
 scaladoc.description = Checks that the ScalaDoc on documentable members is well-formed
+
+indentation.message = Use correct indentation
+indentation.label = Use correct indentation
+indentation.description = Checks that lines are indented by a multiple of the tab size

--- a/src/main/scala/org/scalastyle/file/IndentationChecker.scala
+++ b/src/main/scala/org/scalastyle/file/IndentationChecker.scala
@@ -1,0 +1,95 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.file
+
+import org.scalastyle.FileChecker
+import org.scalastyle.LineError
+import org.scalastyle.Line
+import org.scalastyle.Lines
+import org.scalastyle.ScalastyleError
+
+object NormalizedLine {
+  def normalize(lines: Lines, tabSize: Int) =
+    lines.lines.zipWithIndex map {
+      case (line, index) => NormalizedLine(index + 1, line, tabSize)
+    }
+}
+
+case class NormalizedLine(lineNumber: Int, line: Line, tabSize: Int) {
+  lazy val normalizedText = replaceTabs(line.text, tabSize)
+  lazy val length = normalizedText.length
+  lazy val body = normalizedText dropWhile { _.isWhitespace }
+  lazy val isBlank = { body.length == 0 }
+  lazy val indentDepth = normalizedText prefixLength { _ == ' ' }
+
+  def mkError(args: List[String] = Nil) = LineError(lineNumber, args)
+
+  // generates a string of spaces equal to the width of the tab
+  private def spaces(column: Int, tabSize: Int): String = {
+    val m = column % tabSize
+    String.format("%" + (tabSize - m) + "s", " ")
+  }
+
+  // replaces tabs with spaces equal to the width of the tab
+  private def replaceTabs(s: String, tabSize: Int): String = {
+    val sb = new StringBuilder(s)
+    val len = sb.length
+    var i = 0;
+
+    while (i < len) {
+      if (sb.charAt(i) == '\t') {
+        sb.replace(i, i + 1, spaces(i, tabSize))
+      }
+      i += 1
+    }
+
+    if (sb.endsWith("\r")) {
+      sb.setLength(sb.length-1);
+    }
+
+    sb.toString
+  }
+}
+
+class IndentationChecker extends FileChecker {
+  val DefaultTabSize = 2
+  val errorKey = "indentation"
+
+  private def multiLineComment(line: NormalizedLine) = line.body.startsWith("*")
+
+  private def startsParamList(line: NormalizedLine) = line.body.matches(""".*class.*\([^\)]*""")
+
+  // in multiline comments the last leading space is not part of the indent
+  private def isTabAlligned(line: NormalizedLine): Boolean =
+    (line.indentDepth % line.tabSize) == (if (multiLineComment(line)) 1 else 0)
+
+  private def isSingleIndent(line: NormalizedLine, prior: NormalizedLine): Boolean =
+    (line.indentDepth - prior.indentDepth) > line.tabSize
+
+  private def verifyTabStop(lines: Seq[NormalizedLine]) =
+    for { line <- lines if !isTabAlligned(line) } yield line.mkError()
+
+  private def verifySingleIndent(lines: Seq[NormalizedLine]) =
+    for { Seq(l1, l2) <- lines.sliding(2) if isSingleIndent(l2, l1) && !startsParamList(l1) } yield l2.mkError()
+
+  def verify(lines: Lines): List[ScalastyleError] = {
+    val tabSize = getInt("tabSize", DefaultTabSize)
+
+    val normalizedLines = NormalizedLine.normalize(lines, tabSize) filterNot { _.isBlank }
+    (verifyTabStop(normalizedLines) ++ verifySingleIndent(normalizedLines)).toList
+  }
+}

--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -1,0 +1,126 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.file
+
+import org.junit.Test;
+import org.scalatest.junit.AssertionsForJUnit
+
+// scalastyle:off magic.number
+
+class IndentationCheckerTest extends AssertionsForJUnit with CheckerTest {
+  val key = "indentation"
+  val classUnderTest = classOf[IndentationChecker]
+
+  val cleanSource =
+"""
+/**
+ * Scaladoc comments should pass
+ */
+class A {
+  val foo = 1
+  def bar(a: String) = {
+    a.length
+  }
+}
+
+class B(
+    paramDoubleIndent: Boolean,
+    isAlsoOk: Boolean)
+  extends A
+{
+  override val foo = 2
+  val foobar =
+    Seq(
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+      "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+    )
+}
+"""
+  @Test def testNoErrorsDefaultTabSize() {
+    assertErrors(List(), cleanSource)
+  }
+
+  @Test def forExpression(): Unit = {
+    val source =
+"""
+val id = 50
+for {
+  a <- findA(id)
+  b =  a.b
+  c <- b.cs
+  if c.isEven
+} yield c
+"""
+
+    assertErrors(Nil, source)
+  }
+
+  @Test def DSL(): Unit = {
+    val source =
+"""
+  |val id = 123
+  |val (m, g) = (GroupMember.syntax("m"), Group.syntax("g"))
+  |val groupMember = withSQL {
+  |  select
+  |    .from(GroupMember as m)
+  |    .leftJoin(Group as g)
+  |    .on(m.groupId, g.id)
+  |    .where.eq(m.id, id)
+  |}.map(GroupMember(m, g)).single.apply()
+""".stripMargin
+
+    assertErrors(Nil, source)
+  }
+
+
+  @Test def testNoErrorsSetTabSize() {
+    val source = cleanSource replaceAll("  ", "    ")
+    assertErrors(List(), source, Map("tabSize" -> "4"))
+  }
+
+  @Test def testNoErrorsWithTabs() {
+    val source = cleanSource replaceAll("  ", "\t")
+    assertErrors(List(), source)
+  }
+
+  @Test def testErrorsIncorrectTabSize() {
+    val source =
+"""
+class A {
+ val foo = 1
+   def bar(a: String) = {
+    a.length
+  }
+}
+"""
+    assertErrors(List(lineError(3), lineError(4)), source)
+  }
+
+  @Test def testExtraIndent() {
+    val source =
+"""
+class A {
+  val foo = 1
+  def bar(a: String) = {
+      a.length
+  }
+}
+"""
+    assertErrors(List(lineError(5)), source)
+  }
+}


### PR DESCRIPTION
Inspired from: https://github.com/scalastyle/scalastyle/wiki/Scalastyle-proposed-rules-(Miscellaneous)#indentation

This checker enforces two rules: 
1) Every line must  be indented by a multiple of the specified tab width
2) Indentation should only increase by a single tab width between two subsequent lines

Exceptions: 
1) Blank lines are ignored
2) Multiline comments are indented an extra space (http://docs.scala-lang.org/style/scaladoc.html)
3) Class parameter lists may be indented more than one tab width from the opening of the class (http://docs.scala-lang.org/style/declarations.html#classes)

This checker borrows the code to replace tabs from the FileLineLengthChecker so I moved those methods into a helper class: NormalizedLine.
