### PR TITLE
Generic Scala style to ensure/disallow a space after/before a Token.

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/SpaceAroundTokenChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/SpaceAroundTokenChecker.scala
@@ -1,0 +1,74 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+
+import scalariform.parser.CompilationUnit
+import scalariform.lexer.{TokenType, Token, Tokens}
+import org.scalastyle._
+
+trait SpaceAroundTokenChecker extends ScalariformChecker {
+  val DefaultTokens: String
+  val disallowSpace: Boolean
+  val beforeToken: Boolean
+
+  def verify(ast: CompilationUnit) = {
+    val tokens: Seq[TokenType] = getString("tokens", DefaultTokens).split(",").map(x => TokenType(x.trim))
+    def checkSpaces(left: Token, middle: Token, right: Token) =
+      if (beforeToken) charsBetweenTokens(left, middle) != (if (disallowSpace) 0 else 1)
+      else charsBetweenTokens(middle, right) != (if (disallowSpace) 0 else 1)
+    (for {
+      l@List(left, middle, right) <- ast.tokens.sliding(3)
+      if (l.forall(x => x.tokenType != Tokens.NEWLINE && x.tokenType != Tokens.NEWLINES)
+        && tokens.contains(middle.tokenType)
+        && !middle.associatedWhitespaceAndComments.containsNewline
+        && !right.associatedWhitespaceAndComments.containsNewline
+        && checkSpaces(left, middle, right))
+    } yield {
+      PositionError(middle.offset)
+    }).toList
+  }
+
+}
+
+class EnsureSpaceAfterToken extends SpaceAroundTokenChecker {
+  val errorKey: String = "ensure.single.space.after.token"
+  val DefaultTokens = "COLON, IF"
+  val disallowSpace = false
+  val beforeToken = false
+}
+
+class EnsureSpaceBeforeToken extends SpaceAroundTokenChecker {
+  val errorKey: String = "ensure.single.space.before.token"
+  val DefaultTokens = ""
+  val disallowSpace = false
+  val beforeToken = true
+}
+
+class DisallowSpaceBeforeToken extends SpaceAroundTokenChecker {
+  val errorKey: String = "disallow.space.before.token"
+  val DefaultTokens = "COLON, COMMA, RPAREN"
+  val disallowSpace = true
+  val beforeToken = true
+}
+
+class DisallowSpaceAfterToken extends SpaceAroundTokenChecker {
+  val errorKey: String = "disallow.space.after.token"
+  val DefaultTokens = "LPAREN"
+  val disallowSpace = true
+  val beforeToken = false
+}

--- a/src/test/scala/org/scalastyle/scalariform/SpaceAroundTokenCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SpaceAroundTokenCheckerTest.scala
@@ -1,0 +1,206 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.scalastyle.file.CheckerTest
+import org.scalatest.junit.AssertionsForJUnit
+import org.junit.Test
+
+class DisallowSpaceAfterTokenTest extends AssertionsForJUnit with CheckerTest {
+  override protected val key: String = "disallow.space.after.token"
+  override protected val classUnderTest = classOf[DisallowSpaceAfterToken]
+
+  @Test def testOK(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(i: Int)
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+
+  @Test def testNewLine(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(
+        |i: Int, c: Int)
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testFailureCases(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A( i: Int, c: Int)
+        |
+        |
+      """.stripMargin
+
+    assertErrors(List(columnError(4, 12)), source)
+  }
+}
+
+class DisallowSpaceBeforeTokenTest extends AssertionsForJUnit with CheckerTest {
+  override protected val key: String = "disallow.space.before.token"
+  override protected val classUnderTest = classOf[DisallowSpaceBeforeToken]
+
+  @Test def testOK(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(i: Int)
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+
+  @Test def testNewLine(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(
+        |i: Int, c: Int
+        |)
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testEdgeCases(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |class Dummy[T: Manifest] {
+        |  val a: Int = 0
+        |  // A:B:C
+        |  def b(ch: Int): Int = 1
+        |  d ++: e
+        |  d :\ e
+        |  e /: d
+        |}
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testFailureCases(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |class Dummy[T : Manifest] {
+        |  val a : Int = 0
+        |  // A:B:C
+        |  def b (ch   : Int):    Int = 1
+        |  def c (ch: Int ) : Int = 1
+        |  val d:Int = 2
+        |  val e :Int = 3
+        |}
+        |
+      """.stripMargin
+
+    assertErrors(List(columnError(4, 14), columnError(5, 8), columnError(7, 14), columnError(8, 17),
+      columnError(8, 19), columnError(10, 8)), source)
+  }
+}
+
+class EnsureSpaceAfterTokenTest extends AssertionsForJUnit with CheckerTest {
+  override protected val key: String = "ensure.single.space.after.token"
+  override protected val classUnderTest = classOf[EnsureSpaceAfterToken]
+
+  @Test def testOK(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(i: Int)
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+
+  @Test def testNewLine(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(
+        |i: Int, c: Int
+        |)
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testEdgeCases(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |class Dummy[T: Manifest] {
+        |  val a: Int = 0
+        |  // A:B:C
+        |  def b(ch: Int): Int = 1
+        |  d ++: e
+        |  d :\ e
+        |  e /: d
+        |}
+        |
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testFailureCases(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |class Dummy[T : Manifest] {
+        |  val a : Int = 0
+        |  // A:B:C
+        |  def b (ch   : Int):    Int = 1
+        |  def c (ch: Int ) : Int = 1
+        |  val d:Int = 2
+        |  val e :Int = 3
+        |}
+        |
+      """.stripMargin
+
+    assertErrors(List(columnError(7, 20), columnError(9, 7), columnError(10, 8)), source)
+  }
+}


### PR DESCRIPTION
This should make more sense than having a separate style for every token possible. 
