### PR TITLE
Fixed crash on triple quoted interpolation (ref #103)

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/MultipleStringLiteralsChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/MultipleStringLiteralsChecker.scala
@@ -42,7 +42,7 @@ class MultipleStringLiteralsChecker extends ScalariformChecker {
 
   private def matches(s: String, regex: Regex) = (regex findAllIn (s)).size == 1
 
-  private def strip(s: String) = if (startsAndEndsWith(s, MultiQuote)) Quote + s.substring(MultiQuoteLength,s.length()-MultiQuoteLength) + Quote else s
+  private def strip(s: String) = if (s.length() > MultiQuoteLength*2 && startsAndEndsWith(s, MultiQuote)) Quote + s.substring(MultiQuoteLength,s.length()-MultiQuoteLength) + Quote else s
 
   private def startsAndEndsWith(s: String, sufpre: String) = s.startsWith(sufpre) && s.endsWith(sufpre)
 }


### PR DESCRIPTION
This fixes the crashes in MultipleStringLiteralsChecker with "String index out of range: -3".

I think the root cause (which this PR doesn't address) is that the parser breaks up strings around interpolation variables (as only those parts are string literals), but the quotation marks are then placed just at the beginning of the first, and at the end of the last substring in an interpolation.
