### PR TITLE
TextOutput patch for IntelliJ

### DIFF
--- a/src/main/scala/org/scalastyle/Output.scala
+++ b/src/main/scala/org/scalastyle/Output.scala
@@ -81,16 +81,12 @@ class TextOutput[T <: FileSpec](verbose: Boolean = false, quiet: Boolean = false
       println("[" + messageHelper.text(level.name).toUpperCase + "]" + print(file.name, line, column) +
         Output.findMessage(messageHelper, key, args, customMessage))
     }
-    case StyleException(file, clazz, message, stacktrace, line, column) => if (!quiet || verbose) {
-      println("[ERROR]" + print(file.name, line, column)  + message)
+    case StyleException(file, clazz, message, stackTrace, line, column) => if (!quiet || verbose) {
+      println("[ERROR]" + print(file.name, line, column)  + message + "\n" + stackTrace)
     }
   }
 
   // scalastyle:on regex
-
-  private def print(s: String, no: Option[Int]): String = if (no.isDefined) print(s, "" + no.get) else ""
-
-  private def print(s: String, value: String): String = " " + s + "=" + value
 
   private def print(file: String, line: Option[Int], column: Option[Int]): String = {
      val l = line.getOrElse("")

--- a/src/main/scala/org/scalastyle/Output.scala
+++ b/src/main/scala/org/scalastyle/Output.scala
@@ -78,12 +78,11 @@ class TextOutput[T <: FileSpec](verbose: Boolean = false, quiet: Boolean = false
     case StartFile(file) => if (verbose) println("start file " + file)
     case EndFile(file) => if (verbose) println("end file " + file)
     case StyleError(file, clazz, key, level, args, line, column, customMessage) => if (!quiet || verbose) {
-      println(messageHelper.text(level.name) + print("file", file.name) +
-        print("message", Output.findMessage(messageHelper, key, args, customMessage)) +
-        print("line", line) + print("column", column))
+      println("[" + messageHelper.text(level.name).toUpperCase + "]" + print(file.name, line, column) +
+        Output.findMessage(messageHelper, key, args, customMessage))
     }
     case StyleException(file, clazz, message, stacktrace, line, column) => if (!quiet || verbose) {
-      println("error" + print("file", file.name) + print("message", message) + print("line", line) + print("column", column))
+      println("[ERROR]" + print(file.name, line, column)  + message)
     }
   }
 
@@ -92,6 +91,13 @@ class TextOutput[T <: FileSpec](verbose: Boolean = false, quiet: Boolean = false
   private def print(s: String, no: Option[Int]): String = if (no.isDefined) print(s, "" + no.get) else ""
 
   private def print(s: String, value: String): String = " " + s + "=" + value
+
+  private def print(file: String, line: Option[Int], column: Option[Int]): String = {
+     val l = line.getOrElse("")
+     val c = column.getOrElse("")
+     val msg = s" $file:[$l,$c] "
+     msg
+  }
 }
 
 object XmlOutput {

--- a/src/main/scala/org/scalastyle/scalariform/SpacesAfterPlusChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/SpacesAfterPlusChecker.scala
@@ -23,6 +23,7 @@ import org.scalastyle.ScalastyleError
 import scalariform.lexer.Tokens.LBRACKET
 import scalariform.lexer.Tokens.NEWLINE
 import scalariform.lexer.Tokens.PLUS
+import scalariform.lexer.Tokens.DEF
 import scalariform.parser.CompilationUnit
 
 class SpacesAfterPlusChecker extends ScalariformChecker {
@@ -31,7 +32,8 @@ class SpacesAfterPlusChecker extends ScalariformChecker {
   def verify(ast: CompilationUnit): List[ScalastyleError] = {
     val it = for {
       List(left, middle, right) <- ast.tokens.sliding(3);
-      if (middle.tokenType == PLUS && left.tokenType != LBRACKET && right.tokenType != NEWLINE && charsBetweenTokens(middle, right) == 0)
+      if (middle.tokenType == PLUS && !Seq(LBRACKET, DEF).contains(left.tokenType) && right.tokenType != NEWLINE && charsBetweenTokens(middle,
+         right) == 0)
     } yield {
       PositionError(middle.offset)
     }

--- a/src/test/scala/org/scalastyle/scalariform/SpacesAfterPlusCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SpacesAfterPlusCheckerTest.scala
@@ -82,4 +82,16 @@ object Foobar {
 
     assertErrors(List(), source)
   }
+
+   @Test def testPlusInMethod(): Unit = {
+      val source = """
+package foobar
+
+object Foobar {
+  def +() = 1
+}
+""";
+
+      assertErrors(List(), source)
+   }
 }


### PR DESCRIPTION
I added a little patch to enable IntelliJ and others to better parse for filename and position of an style warning or error. IntelliJs console displays now a clickable link in case of a warning.
