### PR TITLE
Fix `EnsureSingleSpaceAfterTokenChecker` when token is first one on line.

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/SpaceAroundTokenChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/SpaceAroundTokenChecker.scala
@@ -44,7 +44,7 @@ trait SpaceAroundTokenChecker extends ScalariformChecker {
       l @ List(left, middle, right) <- ast.tokens.sliding(3)
       if (l.forall(x => x.tokenType != Tokens.NEWLINE && x.tokenType != Tokens.NEWLINES)
         && tokens.contains(middle.tokenType)
-        && !middle.associatedWhitespaceAndComments.containsNewline
+        && !(middle.associatedWhitespaceAndComments.containsNewline && beforeToken)
         && (!right.associatedWhitespaceAndComments.containsNewline || beforeToken)
         && checkSpaces(left, middle, right))
     } yield {

--- a/src/test/scala/org/scalastyle/scalariform/SpaceAroundTokenCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SpaceAroundTokenCheckerTest.scala
@@ -166,6 +166,20 @@ class EnsureSpaceAfterTokenTest extends AssertionsForJUnit with CheckerTest {
     assertErrors(List(), source)
   }
 
+  @Test def testFirstTokenAfterNewLine(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |case class A(i
+        |  :Int
+        |)
+        |
+      """.stripMargin
+
+    assertErrors(List(columnError(5, 2, List(":"))), source)
+  }
+
   @Test def testEdgeCases(): Unit = {
     val source =
       """


### PR DESCRIPTION
Similar to https://github.com/scalastyle/scalastyle/pull/116.

In this case the token's "associated whitespace" contains a newline. If checking for space _before_ token, then this means the check can be skipped - no need to check for a space before if there is a newline before. The bug is when the check is for space _after_: in this case we do _not_ want to skip the check - having a newline before does not mean we don't want a space after!
