### PR TITLE
Adding examples on the IfBraceChecker

### DIFF
--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -119,6 +119,23 @@ is considered to be a magic number.
  <justification>
  Some people find if clauses with braces easier to read.
  </justification>
+ <extra-description>
+ The singleLineAllowed property allows if constructions of the type:
+
+    if (bool_expression) expression1 else expression2
+
+The doubleLineAllowed property allows if constructions of the type:
+
+    if (bool_expression) expression1
+    else expression2
+
+Note: If you intend to enable only if expressions in the format below, disable the IfBraceChecker altogether.
+
+    if (bool_expression) 
+      expression1
+    else 
+      expression2 
+ </extra-description>
  <example-configuration>
  <![CDATA[
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">


### PR DESCRIPTION
This pull request is intended to address this issue: 

The doubleLineAllowed property could lead to misinterpretations. One could think that this allows the following if code:
if (bool_expression)
expression
else
expression

when instead is allowing: 
if (bool_expression) expression
else expression

To avoid this kinds of misunderstandings the documentation should provide examples