### PR TITLE
Introduce ignoreRegex parameter into the ScalaDocChecker

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -151,7 +151,11 @@
  <check class="org.scalastyle.scalariform.ProcedureDeclarationChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.ForBraceChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" level="warning" enabled="true"></check>
- <check class="org.scalastyle.scalariform.ScalaDocChecker" level="warning" enabled="false"></check>
+ <check class="org.scalastyle.scalariform.ScalaDocChecker" level="warning" enabled="false">
+  <parameters>
+   <parameter name="ignoreRegex"><![CDATA[^$]]></parameter>
+  </parameters>
+ </check>
  <check class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="warning" enabled="false"></check>
  <check class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="warning" enabled="false"></check>
  <check class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="warning" enabled="false"></check>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -261,6 +261,8 @@ space.after.comment.start.description = "Checks a space after the start of the c
 scaladoc.message = "Missing or badly formed ScalaDoc: {0}"
 scaladoc.label = "Missing or badly formed ScalaDoc: {0}"
 scaladoc.description = "Checks that the ScalaDoc on documentable members is well-formed"
+scaladoc.ignoreRegex.label = "Regular expression"
+scaladoc.ignoreRegex.description = "Class names matching this regular expression will be ignored"
 
 disallow.space.after.token.message = "Space after token {0}"
 disallow.space.after.token.label = "Space after tokens"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -139,7 +139,11 @@
     <checker class="org.scalastyle.scalariform.ForBraceChecker" id="for.brace" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" id="space.after.comment.start" defaultLevel="warning"/>
 
-    <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning"/>
+    <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning">
+        <parameters>
+            <parameter name="ignoreRegex" type="string" default="^$"/>
+        </parameters>
+    </checker>
     <checker class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" id="disallow.space.after.token" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" id="disallow.space.before.token" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" id="ensure.single.space.after.token" defaultLevel="warning"/>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -807,7 +807,11 @@ To bring consistency with how comments should be formatted, leave a space right 
  </justification>
  <example-configuration>
  <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true" />
+    <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true">
+      <parameters>
+        <parameter name="ignoreRegex">(.*Spec$)|(.*SpecIT$)</parameter>
+      </parameters>
+    </check>
  ]]>
  </example-configuration>
  </check>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -261,6 +261,8 @@ space.after.comment.start.description = Checks a space after the start and befor
 scaladoc.message = Missing or badly formed ScalaDoc: {0}
 scaladoc.label = Missing or badly formed ScalaDoc: {0}
 scaladoc.description = Checks that the ScalaDoc on documentable members is well-formed
+scaladoc.ignoreRegex.label = "Regular expression"
+scaladoc.ignoreRegex.description = "Class names matching this regular expression will be ignored"
 
 indentation.message = Use correct indentation
 indentation.label = Use correct indentation

--- a/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
@@ -83,6 +83,24 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
     }
   }
 
+  @Test def specClass(): Unit = {
+    val specClassSource = "%sclass FooSpec"
+    val specITClassSource = "%sclass FooSpecIT"
+    val doc =
+      """
+        |/**
+        | * This is the documentation for whatever follows
+        | */
+      """.stripMargin
+
+    List(specClassSource, specITClassSource).foreach { source =>
+      assertErrors(List(lineError(1, List(Missing))), source format "")
+      assertErrors(Nil, source format doc)
+      assertErrors(Nil, source format "", Map("ignoreRegex" -> "(.+Spec$)|(.+SpecIT$)"))
+      assertErrors(Nil, source format doc, Map("ignoreRegex" -> "(.+Spec$)|(.+SpecIT$)"))
+    }
+  }
+
   @Test def typeParamsCCT(): Unit = {
     val traitSource = "%strait Foo[A, B]"
     val classSource = "%sclass Foo[A, B]"


### PR DESCRIPTION
The default ignoreRegex parameter, "^$", should not match any valid class,
trait, method, etc. An ignoreRegex parameter of
"(.+Spec$)|(.+SpecIT$)" will cause ScalaDoc validation of test classes to
be skipped.