### PR TITLE
Multi-line Method Argument Indent

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -295,6 +295,8 @@ indentation.label = Use correct indentation
 indentation.description = Checks that lines are indented by a multiple of the tab size
 indentation.tabSize.label = "Tab size"
 indentation.tabSize.description = "Number of characters that a tab represents"
+indentation.methodParamIndentSize.label = "Multi-line method parameter spacing"
+indentation.methodParamIndentSize.description = "Level of indentation of multi-line method parameters relative to the indentation of the first line of the method"
 
 field.name.message = "Field name does not match the regular expression ''{0}''"
 field.name.label = "Field name"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -148,6 +148,7 @@
     <checker class="org.scalastyle.file.IndentationChecker" id="indentation" defaultLevel="warning">
         <parameters>
             <parameter name="tabSize" type="integer" default="2" />
+            <parameter name="methodParamIndentSize" type="integer" default="2" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.FieldNamesChecker" id="field.name" defaultLevel="warning">

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -691,6 +691,7 @@ To bring consistency with how comments should be formatted, leave a space right 
     <check level="warning" class="org.scalastyle.file.IndentationChecker" enabled="true">
       <parameters>
         <parameter name="tabSize">2</parameter>
+        <parameter name="methodParamIndentSize">2</parameter>
       </parameters>
     </check>
  ]]>

--- a/src/main/scala/org/scalastyle/file/IndentationChecker.scala
+++ b/src/main/scala/org/scalastyle/file/IndentationChecker.scala
@@ -71,9 +71,9 @@ class IndentationChecker extends FileChecker {
 
   private def multiLineComment(line: NormalizedLine) = line.body.startsWith("*")
 
-  private def startsParamList(line: NormalizedLine) = line.body.matches(""".*class.*\([^\)]*""")
+  private def startsParamList(line: NormalizedLine) = line.body.matches(""".*class .*\([^\)]*""")
 
-  private def startsMethodDef(line: NormalizedLine) = line.body.matches(""".*def.*\([^\)]*""")
+  private def startsMethodDef(line: NormalizedLine) = line.body.matches(""".*def .*\([^\)]*""")
 
   // in multiline comments the last leading space is not part of the indent
   private def isTabAlligned(line: NormalizedLine): Boolean =

--- a/src/main/scala/org/scalastyle/file/IndentationChecker.scala
+++ b/src/main/scala/org/scalastyle/file/IndentationChecker.scala
@@ -73,6 +73,8 @@ class IndentationChecker extends FileChecker {
 
   private def startsParamList(line: NormalizedLine) = line.body.matches(""".*class.*\([^\)]*""")
 
+  private def startsMethodDef(line: NormalizedLine) = line.body.matches(""".*def.*\([^\)]*""")
+
   // in multiline comments the last leading space is not part of the indent
   private def isTabAlligned(line: NormalizedLine): Boolean =
     (line.indentDepth % line.tabSize) == (if (multiLineComment(line)) 1 else 0)
@@ -84,7 +86,7 @@ class IndentationChecker extends FileChecker {
     for { line <- lines if !isTabAlligned(line) } yield line.mkError()
 
   private def verifySingleIndent(lines: Seq[NormalizedLine]) =
-    for { Seq(l1, l2) <- lines.sliding(2) if isSingleIndent(l2, l1) && !startsParamList(l1) } yield l2.mkError()
+    for { Seq(l1, l2) <- lines.sliding(2) if isSingleIndent(l2, l1) && !startsParamList(l1) && !startsMethodDef(l1) } yield l2.mkError()
 
   def verify(lines: Lines): List[ScalastyleError] = {
     val tabSize = getInt("tabSize", DefaultTabSize)

--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -172,4 +172,21 @@ class A {
     assertErrors(List(lineError(4)), source)
     assertErrors(List(lineError(4)), source, Map("methodParamIndentSize" -> "4"))
   }
+
+  /**
+   * Check that we don't accidentally think that val defintions are method defintions just because
+   * it includes the word def, and complain about subsequent method argument indentation
+   */
+  @Test def testValNotConsideredMethod(): Unit = {
+    val source =
+"""
+class A {
+  val defSomething = Map(
+    "ehllo" -> "world"
+  )
+}
+"""
+
+    assertErrors(List(), source, Map("methodParamIndentSize" -> "4"))
+  }
 }

--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -49,6 +49,12 @@ class B(
       "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
       "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
     )
+
+  def longMethodWithDoubleIndentParams(
+      paramDoubleIndent: Boolean,
+      isAlsoOk: Boolean): Unit = {
+    "ab"
+  }
 }
 """
   @Test def testNoErrorsDefaultTabSize(): Unit = {

--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -50,11 +50,9 @@ class B(
       "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
     )
 
-  def longMethodWithDoubleIndentParams(
-      paramDoubleIndent: Boolean,
-      isAlsoOk: Boolean): Unit = {
-    "ab"
-  }
+  def methodWithMultilineParams(
+    paramDoubleIndent: Boolean,
+    isAlsoOk: Boolean): Unit = {}
 }
 """
   @Test def testNoErrorsDefaultTabSize(): Unit = {
@@ -128,5 +126,50 @@ class A {
 }
 """
     assertErrors(List(lineError(5)), source)
+  }
+
+  @Test def testCorrectMethodParamIndent(): Unit = {
+    val source =
+"""
+class A {
+  def longMethodWithCorrectIndentParams(
+      paramDoubleIndent: Boolean,
+      isAlsoOk: Boolean): Unit = {
+  }
+}
+"""
+
+    assertErrors(List(lineError(4)), source)
+    assertErrors(List(), source, Map("methodParamIndentSize" -> "4"))
+  }
+
+  @Test def testMethodParamUnderIndent(): Unit = {
+    val source =
+"""
+class A {
+  def longMethodWithUnderIndentedParams(
+    paramDoubleIndent: Boolean,
+    isAlsoOk: Boolean): Unit = {
+  }
+}
+"""
+
+    assertErrors(List(), source)
+    assertErrors(List(lineError(4)), source, Map("methodParamIndentSize" -> "4"))
+  }
+
+  @Test def testMethodParamOverIndent(): Unit = {
+    val source =
+"""
+class A {
+  def longMethodWithOverIndentedParams(
+        paramDoubleIndent: Boolean,
+        isAlsoOk: Boolean): Unit = {
+  }
+}
+"""
+
+    assertErrors(List(lineError(4)), source)
+    assertErrors(List(lineError(4)), source, Map("methodParamIndentSize" -> "4"))
   }
 }


### PR DESCRIPTION
Adds an option to IndentationChecker, `methodParamIndentSize` to set the indentation of multi-line method definitions. This setting defaults to be the same as the `tabSize`, preserving the current default behavior.

Example:
With the default setting of 2 for `methodParamIndentSize`, the following is invalid. 
```
def longMethodWithCorrectIndentParams(
    paramDoubleIndent: Boolean,
    isAlsoOk: Boolean): Unit = {
  ...
}
```
With a setting of 4, it is considered valid.