### PR TITLE
#153 Add a rule to check the indentation at a class declaration across multiple lines

### DIFF
--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -94,7 +94,7 @@ for {
 
   @Test def testNoErrorsSetTabSize(): Unit = {
     val source = cleanSource replaceAll("  ", "    ")
-    assertErrors(List(), source, Map("tabSize" -> "4"))
+    assertErrors(List(), source, Map("tabSize" -> "4", "classParamIndentSize" -> "8"))
   }
 
   @Test def testNoErrorsWithTabs(): Unit = {


### PR DESCRIPTION
[Add a rule to check the indentation at a class declaration across multiple lines · Issue #153 · scalastyle/scalastyle](https://github.com/scalastyle/scalastyle/issues/153)

I wonder if we should set default value for `classParamIndentSize` as 4 or `tabSize`. What do everyone think?

---
### classParamIndentSize = 4 (Default)

```
class Person(
    name: String,
    age: Int,
    birthdate: Date,
    astrologicalSign: String,
    shoeSize: Int,
    favoriteColor: java.awt.Color) {
  def firstMethod: Foo = ...
}
```

### classParamIndentSize = 2

```
class Person(
  name: String,
  age: Int,
  birthdate: Date,
  astrologicalSign: String,
  shoeSize: Int,
  favoriteColor: java.awt.Color) {
  def firstMethod: Foo = ...
}
```