### PR TITLE
Enable Scoverage and Codecov and add badges to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ scala:
 jdk:
   - oraclejdk7
   - openjdk7
+sudo: false
 notifications:
   email:
     - matthew@farwell.co.uk
 before_install:
   - pip install --user codecov
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION coverage test
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ Scalastyle examines your Scala code and indicates potential problems with it.
 
 Full documentation is currently available [on the Scalastyle website](http://www.scalastyle.org/)
 
-Updated to build with Travis and run code coverage with codecov.io
+[![Build Status](https://travis-ci.org/scalastyle/scalastyle.svg?branch=master)](https://travis-ci.org/scalastyle/scalastyle)
+[![codecov.io](https://codecov.io/github/scalastyle/scalastyle.svg/coverage.svg?branch=master)](https://codecov.io/github/scalastyle/scalastyle.svg?branch=master)

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,11 @@ fork in Test := true
 
 javaOptions in Test += "-Dfile.encoding=UTF-8"
 
+coverageHighlighting := {
+  if (scalaBinaryVersion.value == "2.10") false
+  else true
+}
+
 publishMavenStyle := true
 
 publishTo := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % "0.13")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")


### PR DESCRIPTION
I noticed that @rigoford added Codecov uploading to the build in caba1e61881a07099457c3af65a86171e74ebea6, but this didn't produce any reports because the build itself does not collect coverage.

This commit updates the build to collect coverage metrics and updates the README to link to the Travis and Codecov statuses in order to make them easier to find.