### PR TITLE
Add an option to ignore reporting on entire lines that are whitespace…

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -26,7 +26,11 @@
   </parameters>
  </check>
  <check class="org.scalastyle.scalariform.SpacesAfterPlusChecker" level="warning" enabled="true"></check>
- <check class="org.scalastyle.file.WhitespaceEndOfLineChecker" level="warning" enabled="true"></check>
+ <check class="org.scalastyle.file.WhitespaceEndOfLineChecker" level="warning" enabled="true">
+   <parameters>
+    <parameter name="ignoreWhitespaceLines"><![CDATA[false]]></parameter>
+   </parameters>
+ </check>
  <check class="org.scalastyle.scalariform.SpacesBeforePlusChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.file.FileLineLengthChecker" level="warning" enabled="true">
   <parameters>

--- a/lib/scalastyle_scala_config.xml
+++ b/lib/scalastyle_scala_config.xml
@@ -26,7 +26,9 @@
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="false"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="false">
+   <parameter name="ignoreWhitespaceLines"><![CDATA[false]]></parameter>
+ </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="false"></check>
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>

--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -26,7 +26,11 @@
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true">
+   <parameters>
+    <parameter name="ignoreWhitespaceLines"><![CDATA[false]]></parameter>
+   </parameters>
+ </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,6 +41,9 @@ spaces.after.plus.description = "Check that the plus sign is followed by a space
 whitespace.end.of.line.message = "Whitespace at end of line"
 whitespace.end.of.line.label = "Whitespace at end of line"
 whitespace.end.of.line.description = "Check that there is no trailing whitespace at the end of lines"
+whitespace.end.of.line.ignoreWhitespaceLines.label = "Ignore lines with just whitespace"
+whitespace.end.of.line.ignoreWhitespaceLines.description = "Skip a line if the entire contents are whitespace characters"
+
 
 spaces.before.plus.message = "There should be a space before the plus (+) sign"
 spaces.before.plus.label = "Space before plus"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--  scalastyle definition file. This contains the list of checkers and the parameters & types available -->
 <scalastyle-definition>
-	<checker class="org.scalastyle.file.FileTabChecker" id="line.contains.tab" defaultLevel="warning"/>
+    <checker class="org.scalastyle.file.FileTabChecker" id="line.contains.tab" defaultLevel="warning"/>
     <checker class="org.scalastyle.file.FileLengthChecker" id="file.size.limit" defaultLevel="warning">
         <parameters>
             <parameter name="maxFileLength" type="integer" default="1500"/>
@@ -13,15 +13,19 @@
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.SpacesAfterPlusChecker" id="spaces.after.plus" defaultLevel="warning" />
-    <checker class="org.scalastyle.file.WhitespaceEndOfLineChecker" id="whitespace.end.of.line" defaultLevel="warning" />
+    <checker class="org.scalastyle.file.WhitespaceEndOfLineChecker" id="whitespace.end.of.line" defaultLevel="warning">
+        <parameters>
+            <parameter name="ignoreWhitespaceLines" type="boolean" default="false" />
+        </parameters>
+    </checker>
     <checker class="org.scalastyle.scalariform.SpacesBeforePlusChecker" id="spaces.before.plus" defaultLevel="warning" />
-	<checker class="org.scalastyle.file.FileLineLengthChecker" id="line.size.limit" defaultLevel="warning" >
-		<parameters>
+    <checker class="org.scalastyle.file.FileLineLengthChecker" id="line.size.limit" defaultLevel="warning" >
+        <parameters>
             <parameter name="maxLineLength" type="integer" default="160" />
             <parameter name="tabSize" type="integer" default="4" />
             <parameter name="ignoreImports" type="boolean" default="false" />
-		</parameters>
-	</checker>
+        </parameters>
+    </checker>
     <checker class="org.scalastyle.scalariform.ClassNamesChecker" id="class.name" defaultLevel="warning">
         <parameters>
             <parameter name="regex" type="string" default="^[A-Z][A-Za-z]*$" />

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -718,7 +718,11 @@ To bring consistency with how comments should be formatted, leave a space right 
  </justification>
  <example-configuration>
  <![CDATA[
-    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true" />
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true">
+     <parameters>
+      <parameter name="ignoreWhitespaceLines" type="boolean" default="false" />
+     </parameters>
+    </check>
  ]]>
  </example-configuration>
  </check>

--- a/src/test/resources/config/scalastyle_config.xml
+++ b/src/test/resources/config/scalastyle_config.xml
@@ -26,7 +26,11 @@
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true">
+   <parameters>
+    <parameter name="ignoreWhitespaceLines"><![CDATA[false]]></parameter>
+   </parameters>
+ </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>

--- a/src/test/scala/org/scalastyle/file/WhitespaceEndOfLineCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/WhitespaceEndOfLineCheckerTest.scala
@@ -65,4 +65,35 @@ object Foobar {
 
     assertErrors(List(columnError(2, 14), columnError(3, 13)), source)
   }
+
+  @Test def testThree(): Unit = {
+    val source = s"""
+package foobar
+
+  object Foobar {
+    val foo = "foo"
+~~
+    val bar = "bar"
+##
+  }
+""".replaceAll("~", " ").replaceAll("#", "\t");
+
+    assertErrors(List(), source, Map("ignoreWhitespaceLines" -> "true"))
+  }
+
+  @Test def testFour(): Unit = {
+    val source =
+      s"""
+package foobar
+
+  object Foobar {
+    val foo = "foo"
+~~
+    val bar = "bar"
+##
+  }
+""".replaceAll("~", " ").replaceAll("#", "\t");
+
+    assertErrors(List(columnError(6, 0), columnError(8, 0)), source, Map("ignoreWhitespaceLines" -> "false"))
+  }
 }


### PR DESCRIPTION
… for WhitespaceEndOfLineChecker

I didn't spend too much time on this, so a good review would be helpful.  All of the current and new tests pass tho. 

IntelliJ defaults adding spaces at the current indentation level for even blank lines, it would be a pain in the ass for us to "fix" all of those.  I do like seeing where there are trailing spaces on real code though.