### PR TITLE
Fix double blank lines regular expression

### DIFF
--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -66,7 +66,7 @@ is considered to be a magic number.
  <![CDATA[
     <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
       <parameters>
-        <parameter name="regex">(?m)^\s\*$(\r|)\n^\s*$(\r|)\n</parameter>
+        <parameter name="regex">(?m)^\s*$(\r|)\n^\s*$(\r|)\n</parameter>
         <parameter name="line">false</parameter>
       </parameters>
       <customMessage>No double blank lines</customMessage>


### PR DESCRIPTION
There is an extra slash in the sample regular expression that prevents it from working as expected.

Relates to https://github.com/scalastyle/scalastyle.github.com/pull/16