### PR TITLE
Add check for package names against regex

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -44,6 +44,11 @@
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
+ <check level="warning" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
  <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -106,6 +106,12 @@ structural.type.message = "Avoid using structural types"
 structural.type.label = "Structural type"
 structural.type.description = "Check that structural types are not used."
 
+package.name.message = "Package name does not match the regular expression ''{0}''"
+package.name.label = "Package name"
+package.name.description = "Check that package names match a regular expression"
+package.name.regex.label = "Regular expression"
+package.name.regex.description = "The package names must match this regular expression"
+
 package.object.name.message = "Package object name does not match the regular expression ''{0}''"
 package.object.name.label = "Package object name"
 package.object.name.description = "Check that package object names match a regular expression"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -32,6 +32,11 @@
             <parameter name="regex" type="string" default="^[A-Z][A-Za-z]*$" />
         </parameters>
     </checker>
+    <checker class="org.scalastyle.scalariform.PackageNamesChecker" id="package.name" defaultLevel="warning">
+        <parameters>
+            <parameter name="regex" type="string" default="^[a-z][A-Za-z]*$" />
+        </parameters>
+    </checker>
     <checker class="org.scalastyle.scalariform.PackageObjectNamesChecker" id="package.object.name" defaultLevel="warning">
         <parameters>
             <parameter name="regex" type="string" default="^[a-z][A-Za-z]*$" />

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -613,6 +613,21 @@ To bring consistency with how comments should be formatted, leave a space right 
  </example-configuration>
  </check>
 
+ <check id="package.name">
+ <justification>
+ The Scala style guide recommends that package names conform to certain standards.
+ </justification>
+ <example-configuration>
+ <![CDATA[
+    <check level="warning" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
+      <parameters>
+        <parameter name="regex">^[a-z][A-Za-z]*$</parameter>
+      </parameters>
+    </check>
+ ]]>
+ </example-configuration>
+ </check>
+
  <check id="package.object.name">
  <justification>
  The Scala style guide recommends that package object names conform to certain standards.

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -106,6 +106,12 @@ structural.type.message = Avoid using structural types
 structural.type.label = Structural type
 structural.type.description = Check that structural types are not used.
 
+package.name.message = Package name does not match the regular expression ''{0}''
+package.name.label = Package name
+package.name.description = Check that package names match a regular expression
+package.name.regex.label = Regular expression
+package.name.regex.description = The package names must match this regular expression
+
 package.object.name.message = Package object name does not match the regular expression ''{0}''
 package.object.name.label = Package object name
 package.object.name.description = Check that package object names match a regular expression

--- a/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
@@ -97,6 +97,90 @@ package object foobar {
 }
 
 
+class PackageNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
+  val key = "package.name"
+  val classUnderTest = classOf[PackageNamesChecker]
+
+  @Test def testSinglePartNoError(): Unit = {
+    val source = """
+package foobar
+""";
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testSinglePartError(): Unit = {
+    val source = """
+package FooBar
+""";
+
+    assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$"))), source)
+  }
+
+  @Test def testMultiPartNoError(): Unit = {
+    val source = """
+package abc.foobar
+""";
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testMultiPartError(): Unit = {
+    val source = """
+package abc.foo_bar
+""";
+
+    assertErrors(List(columnError(2, 12, List("^[a-z][A-Za-z]*$"))), source)
+  }
+
+  @Test def testPackageObjectNoError(): Unit = {
+    val source = """
+package object _foo_bar
+""";
+
+    assertErrors(List(), source)
+  }
+
+  // Check case where the package name is built up by successive package statements.
+  @Test def testMultiLinePackageNoError(): Unit = {
+    val source = """
+package foo
+package bar
+""";
+
+    assertErrors(List(), source)
+  }
+
+  // Check case where the package name is built up by successive package statements.
+  @Test def testMultiLinePackageError(): Unit = {
+    val source = """
+package foo
+package Bar
+""";
+
+    assertErrors(List(columnError(3, 8, List("^[a-z][A-Za-z]*$"))), source)
+  }
+
+  @Test def testMultiLinePackageMultipleError(): Unit = {
+    val source = """
+package Foo
+package Bar
+""";
+
+    assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$")), columnError(3, 8, List("^[a-z][A-Za-z]*$"))), source)
+  }
+
+  @Test def testPackageAndPackageObjectNoError(): Unit = {
+    val source = """
+package org.thisone
+package object _foo
+""";
+
+    assertErrors(List(), source)
+  }
+
+}
+
 class PackageObjectNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val key = "package.object.name"
   val classUnderTest = classOf[PackageObjectNamesChecker]


### PR DESCRIPTION
Existing check is only for package object names. Added support to check
each of the components of the package name iteslf. Works even if the
package is specified on multiple lines, like
  package org.thisone
  package util