### PR TITLE
Fix indentation check for classes where invocation is mistaken for a parameter list

### DIFF
--- a/src/main/scala/org/scalastyle/file/IndentationChecker.scala
+++ b/src/main/scala/org/scalastyle/file/IndentationChecker.scala
@@ -102,7 +102,7 @@ class IndentationChecker extends FileChecker {
    */
   private def verifyClassIndent(lines: Seq[NormalizedLine], classParamIndentSize: Int) = {
     def isInvalid(l1: NormalizedLine, l2: NormalizedLine): Boolean = {
-      if (startsParamList(l1)) {
+      if (startsParamList(l1) && !l1.normalizedText.contains(" extends ")) {
         (l2.indentDepth - l1.indentDepth) != classParamIndentSize
       } else {
         false

--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -189,4 +189,16 @@ class A {
 
     assertErrors(List(), source, Map("methodParamIndentSize" -> "4"))
   }
+
+  @Test def testExtendNotConsideredClassIndent(): Unit = {
+    val source =
+"""
+object A extends B(
+  a, b, c, d) {
+
+}
+"""
+
+    assertErrors(List(), source, Map("classParamIndentSize" -> "4"))
+  }
 }


### PR DESCRIPTION
Currently, the regex considers a class to start a parameter list if it contains "class", "object", or "trait" and is followed by a left-paren. However, this is incorrect in the example:
``
object A extends B(
  a, b, c)
``
as it is not a parameter list, but constructor/method invocation.