### PR TITLE
ScalaDocChecker: Add ignoreTokenTypes option

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -284,6 +284,8 @@ scaladoc.label = "Missing or badly formed ScalaDoc: {0}"
 scaladoc.description = "Checks that the ScalaDoc on documentable members is well-formed"
 scaladoc.ignoreRegex.label = "Regular expression"
 scaladoc.ignoreRegex.description = "Class names matching this regular expression will be ignored"
+scaladoc.ignoreTokenTypes.label = "Comma Separated String"
+scaladoc.ignoreTokenTypes.description = "Include the following to ignore : PatDefOrDcl (variables), TmplDef (classes, traits), TypeDefOrDcl (type definitions), FunDefOrDcl (functions)"
 
 disallow.space.after.token.message = "Space after token {0}"
 disallow.space.after.token.label = "Space after tokens"
@@ -340,4 +342,3 @@ todo.comment.label = "TODO/FIXME comment"
 todo.comment.description = "Check for use of TODO/FIXME single line comments"
 todo.comment.words.label = "Word list"
 todo.comment.words.description = "Alternative list of words to look for, separated by |"
-

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -152,6 +152,7 @@
     <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning">
         <parameters>
             <parameter name="ignoreRegex" type="string" default="^$"/>
+						<parameter name="ignoreTokenTypes" type="string" default="^$"/>
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" id="disallow.space.after.token" defaultLevel="warning"/>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -839,11 +839,15 @@ To bring consistency with how comments should be formatted, leave a space right 
  <justification>
  Scaladoc is generally considered a good thing. Within reason.
  </justification>
+ <extra-description>
+ Ignore tokens is a comma separated string that may include the following : PatDefOrDcl (variables), TmplDef (classes, traits), TypeDefOrDcl (type definitions), FunDefOrDcl (functions)
+ </extra-description>
  <example-configuration>
  <![CDATA[
     <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true">
       <parameters>
         <parameter name="ignoreRegex">(.*Spec$)|(.*SpecIT$)</parameter>
+        <parameter name="ignoreTokenTypes">PatDefOrDcl,TypeDefOrDcl,FunDefOrDcl,TmplDef</parameter>
       </parameters>
     </check>
  ]]>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -279,6 +279,8 @@ scaladoc.label = Missing or badly formed ScalaDoc: {0}
 scaladoc.description = Checks that the ScalaDoc on documentable members is well-formed
 scaladoc.ignoreRegex.label = "Regular expression"
 scaladoc.ignoreRegex.description = "Class names matching this regular expression will be ignored"
+scaladoc.ignoreTokenTypes.label = Comma Separated String
+scaladoc.ignoreTokenTypes.description = "Include the following to ignore : PatDefOrDcl (variables), TmplDef (classes, traits), TypeDefOrDcl (type definitions), FunDefOrDcl (functions)"
 
 indentation.message = Use correct indentation
 indentation.label = Use correct indentation

--- a/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
@@ -372,4 +372,18 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
     assertErrors(List(lineError(7, List(Missing))), source)
   }
 
+  @Test def ignoreTokenTypes(): Unit = {
+
+    val cases = Seq(Seq("val a = 1", "var a = 2") -> "PatDefOrDcl",
+      Seq("class A", "case class A", "object A", "trait A") -> "TmplDef",
+      Seq("type B = A") -> "TypeDefOrDcl",
+      Seq("def A(): Unit") -> "FunDefOrDcl")
+
+    for ((declerations, ignoreTokenType) <- cases;
+         decleration <- declerations) {
+      assertErrors(Nil, decleration, Map("ignoreTokenTypes" -> ignoreTokenType))
+    }
+  }
+
+
 }


### PR DESCRIPTION
Possible fix for #173 

New option named `ignoreTokenTypes`, the possible values (separated by commas) are :  

- `PatDefOrDcl` for variables 
- `TmplDef` for classes / traits
- `TypeDefOrDcl` for type definitions
- `FunDefOrDcl` for functions

I guess I can change the names of the options to be more indicative.