### PR TITLE
[Maintenance] Fix triple-quotes with stripMargin and semi-colons.

### DIFF
--- a/src/main/scala/org/scalastyle/PrintAst.scala
+++ b/src/main/scala/org/scalastyle/PrintAst.scala
@@ -22,16 +22,18 @@ import _root_.scalariform.lexer.Token
 
 object PrintAst {
   def main(args: Array[String]): Unit = {
-    val source = """package foobar
-class Foobar {
-  def foobar() = {
-    val f1 = 5
-    val f2 = 5 :: Nil
-
-    println("it=" + it.toList)
-  }
-}
-"""
+    val source = 
+    """
+      |package foobar
+      |class Foobar {
+      |  def foobar() = {
+      |    val f1 = 5
+      |    val f2 = 5 :: Nil
+      |
+      |    println("it=" + it.toList)
+      |  }
+      |}
+    """.stripMargin.trim
 
     printAst(source)
   }

--- a/src/test/scala/org/scalastyle/CommentFilterDisabledTest.scala
+++ b/src/test/scala/org/scalastyle/CommentFilterDisabledTest.scala
@@ -30,16 +30,17 @@ class CommentFilterDisabledTest extends CheckerTest {
   val classUnderTest = classOf[FileLengthChecker]
 
   @Test def testOne(): Unit = {
-    val source = """
-
-      // scalastyle:off
-package foobar
-
-  object Foobar {
-}
-  object Barbar {
-}
-""";
+    val source =
+    """
+      |
+      |      // scalastyle:off
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+      |  object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(fileError(List("5"))), source, Map("maxFileLength" -> "5"), commentFilter = false)
   }

--- a/src/test/scala/org/scalastyle/CommentFilterTest.scala
+++ b/src/test/scala/org/scalastyle/CommentFilterTest.scala
@@ -25,10 +25,12 @@ import org.junit.Test
 
 class CommentFilterTest extends AssertionsForJUnit {
   @Test def testTokens(): Unit = {
-    val text = """
-// scalastyle:off
-      // another comment
-// scalastyle:on"""
+    val text =
+    """
+      |// scalastyle:off
+      |      // another comment
+      |// scalastyle:on
+    """.stripMargin
     val comments = new CheckerUtils().parseScalariform(text).get.comments
 
     val tokens = CommentFilter.findScalastyleComments(comments)
@@ -37,53 +39,63 @@ class CommentFilterTest extends AssertionsForJUnit {
   }
 
   @Test def testOffOn(): Unit = {
-    assertCommentFilter(List(CommentFilter(None, Some(LineColumn(2, 0)),Some(LineColumn(3, 0)))), """
-// scalastyle:off
-// scalastyle:on""")
+    assertCommentFilter(List(CommentFilter(None, Some(LineColumn(2, 0)),Some(LineColumn(3, 0)))),
+    """
+      |// scalastyle:off
+      |// scalastyle:on
+    """.stripMargin)
   }
 
   @Test def testOffOnVariousWhitespace(): Unit = {
-    assertCommentFilter(List(CommentFilter(None, Some(LineColumn(2, 0)),Some(LineColumn(3, 1)))), """
-//  scalastyle:off
- //  scalastyle:on """)
+    assertCommentFilter(List(CommentFilter(None, Some(LineColumn(2, 0)),Some(LineColumn(3, 1)))),
+    """
+      |//  scalastyle:off
+      | //  scalastyle:on
+    """.stripMargin)
   }
 
   @Test def testOffOnIds(): Unit = {
     assertCommentFilter(List(CommentFilter(Some("magic.number"), Some(LineColumn(2, 0)),Some(LineColumn(4, 0))),
-        CommentFilter(Some("class.name"), Some(LineColumn(3, 0)),Some(LineColumn(5, 1)))), """
-//  scalastyle:off magic.number
-//  scalastyle:off class.name
-//  scalastyle:on magic.number
- //  scalastyle:on class.name""")
+        CommentFilter(Some("class.name"), Some(LineColumn(3, 0)),Some(LineColumn(5, 1)))),
+        """
+          |//  scalastyle:off magic.number
+          |//  scalastyle:off class.name
+          |//  scalastyle:on magic.number
+          | //  scalastyle:on class.name
+        """.stripMargin)
   }
 
   @Test def testOffOnMultipleIds(): Unit = {
     assertCommentFilter(List(CommentFilter(Some("magic.number"), Some(LineColumn(2, 0)),Some(LineColumn(4, 0))),
         CommentFilter(Some("class.name"), Some(LineColumn(3, 0)),Some(LineColumn(5, 1))),
-        CommentFilter(Some("object.name"), Some(LineColumn(2, 0)), None)), """
-//  scalastyle:off magic.number object.name
-//  scalastyle:off class.name
-//  scalastyle:on magic.number
- //  scalastyle:on class.name""")
+        CommentFilter(Some("object.name"), Some(LineColumn(2, 0)), None)),
+        """
+          |//  scalastyle:off magic.number object.name
+          |//  scalastyle:off class.name
+          |//  scalastyle:on magic.number
+          | //  scalastyle:on class.name
+        """.stripMargin)
   }
 
   @Test def testOffOnOpenEnds(): Unit = {
     assertCommentFilter(List(CommentFilter(Some("magic.number"), Some(LineColumn(2, 0)),Some(LineColumn(3, 0))),
         CommentFilter(Some("object.name"), Some(LineColumn(5, 1)), None),
-        CommentFilter(Some("class.name"), Some(LineColumn(2, 0)), None)), """
-//  scalastyle:off magic.number class.name
-//  scalastyle:on magic.number
-//  scalastyle:on magic.number
- //  scalastyle:off object.name
-""")
+        CommentFilter(Some("class.name"), Some(LineColumn(2, 0)), None)),
+        """
+          |//  scalastyle:off magic.number class.name
+          |//  scalastyle:on magic.number
+          |//  scalastyle:on magic.number
+          | //  scalastyle:off object.name
+        """.stripMargin)
   }
 
   @Test def testOneLine(): Unit = {
-    val source = """
-// scalastyle:ignore
- // scalastyle:ignore test
-some code //   scalastyle:ignore
-"""
+    val source =
+    """
+      |// scalastyle:ignore
+      | // scalastyle:ignore test
+      |some code //   scalastyle:ignore
+    """.stripMargin
   val expected = List( CommentFilter(None         ,Some(LineColumn(2,0)), Some(LineColumn(3,0)) )
                      , CommentFilter(Some("test") ,Some(LineColumn(3,0)), Some(LineColumn(4,0)) )
                      , CommentFilter(None         ,Some(LineColumn(4,0)), Some(LineColumn(5,0)) )
@@ -93,13 +105,14 @@ some code //   scalastyle:ignore
 
 
   @Test def testCombination(): Unit = {
-    val source = """
-// scalastyle:off magic.number
-// scalastyle:ignore magic.number
-// scalastyle:on magic.number
-// scalastyle:ignore magic.number
-// scalastyle:off magic.number
-"""
+    val source =
+    """
+      |// scalastyle:off magic.number
+      |// scalastyle:ignore magic.number
+      |// scalastyle:on magic.number
+      |// scalastyle:ignore magic.number
+      |// scalastyle:off magic.number
+    """.stripMargin
   val expected = List(CommentFilter(Some("magic.number"), Some(LineColumn(3,0)), Some(LineColumn(4,0)))
                      , CommentFilter(Some("magic.number"), Some(LineColumn(5,0)), Some(LineColumn(6,0)))
                      , CommentFilter(Some("magic.number"), Some(LineColumn(2,0)), Some(LineColumn(4,0)))
@@ -110,27 +123,28 @@ some code //   scalastyle:ignore
 
 
   @Test def testCombination2(): Unit = {
-    val source = """
-package foobar
-
-class foobar {
-  // scalastyle:on class.name
-  class barbar1 { } // scalastyle:ignore class.name
-  //
-
-  // scalastyle:on
-  class barbar2 { } // scalastyle:ignore
-  // scalastyle:off
-
-  // scalastyle:on
-  class barbar3 { } // scalastyle:ignore class.name
-  // scalastyle:off
-
-  // scalastyle:on
-  class barbar4 { } // scalastyle:ignore magic.number
-  // scalastyle:off
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class foobar {
+      |  // scalastyle:on class.name
+      |  class barbar1 { } // scalastyle:ignore class.name
+      |  //
+      |
+      |  // scalastyle:on
+      |  class barbar2 { } // scalastyle:ignore
+      |  // scalastyle:off
+      |
+      |  // scalastyle:on
+      |  class barbar3 { } // scalastyle:ignore class.name
+      |  // scalastyle:off
+      |
+      |  // scalastyle:on
+      |  class barbar4 { } // scalastyle:ignore magic.number
+      |  // scalastyle:off
+      |}
+    """.stripMargin
   val expected = List( CommentFilter(Some("class.name"),   Some(LineColumn(6,0)), Some(LineColumn(7,0)))
                      , CommentFilter(None              ,   Some(LineColumn(10,0)), Some(LineColumn(11,0)))
                      , CommentFilter(Some("class.name"),   Some(LineColumn(14,0)), Some(LineColumn(15,0)))

--- a/src/test/scala/org/scalastyle/CustomIdTest.scala
+++ b/src/test/scala/org/scalastyle/CustomIdTest.scala
@@ -31,14 +31,15 @@ class CustomIdTest extends CheckerTest {
   val message = Some("custom")
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-  object Foobar {
-}
-  object Barbar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+      |  object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(fileError(List("5"), message)), source, Map("maxFileLength" -> "5"), message, customId = Some("this.is.custom"))
   }

--- a/src/test/scala/org/scalastyle/CustomMessageTest.scala
+++ b/src/test/scala/org/scalastyle/CustomMessageTest.scala
@@ -31,14 +31,15 @@ class CustomMessageTest extends CheckerTest {
   val message = Some("custom")
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-  object Foobar {
-}
-  object Barbar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+      |  object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(fileError(List("5"), message)), source, Map("maxFileLength" -> "5"), message)
   }

--- a/src/test/scala/org/scalastyle/FileEncodingTest.scala
+++ b/src/test/scala/org/scalastyle/FileEncodingTest.scala
@@ -20,9 +20,9 @@ import org.scalatest.junit.AssertionsForJUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.BufferedWriter;
-import java.io.OutputStreamWriter;
-import java.io.FileOutputStream;
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+import java.io.FileOutputStream
 
 class FileEncodingTest extends AssertionsForJUnit {
   val TestString = "foobar\u00E9\u00A8\u00E0$\u00E9\u00E8\u00E8\u00A8\u00E8\u00A8"
@@ -45,12 +45,12 @@ class FileEncodingTest extends AssertionsForJUnit {
   }
 
   private def createFile(encoding: String) = {
-    val filename = "target/test/fileEncodingTest." + encoding + ".txt";
+    val filename = "target/test/fileEncodingTest." + encoding + ".txt"
 
-    new java.io.File("target").mkdir();
-    new java.io.File("target/test").mkdir();
+    new java.io.File("target").mkdir()
+    new java.io.File("target/test").mkdir()
 
-    val out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(filename), encoding));
+    val out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(filename), encoding))
     out.write(TestString)
     out.close()
 

--- a/src/test/scala/org/scalastyle/OutputTest.scala
+++ b/src/test/scala/org/scalastyle/OutputTest.scala
@@ -27,67 +27,69 @@ import com.typesafe.config.ConfigFactory
 // scalastyle:off magic.number multiple.string.literals
 
 class OutputTest extends AssertionsForJUnit {
- @Test
- @Ignore("doesn't work under 2.9")
- def testXmlOutput(): Unit = {
-   val fooSpec = new FileSpec { def name: String = "foo" }
-   val barSpec = new FileSpec { def name: String = "bar" }
-
-   val messages = List(
-       StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(1), Some(2), Some("custom")),
-       StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(3), Some(4), Some("custom 3")),
-       StyleError(barSpec, classOf[FileLengthChecker], "barbar", WarningLevel, List[String](), None, None, None),
-       StyleError(barSpec, classOf[FileLengthChecker], "bazbar", InfoLevel, List[String](), None, None, None),
-       StyleException(barSpec, Some(classOf[FileLengthChecker]), "bazbaz", "stacktrace\nstacktrace", Some(5), Some(6)),
-       StyleException(barSpec, None, "noClass", "stacktrace\nstacktrace", Some(7), Some(8))
-   )
-
-   new java.io.File("target").mkdir();
-   new java.io.File("target/test").mkdir();
-
-   XmlOutput.save(ConfigFactory.load(), "target/test/OutputTest.xml", "UTF-8", messages);
-
-   val lineSep = System.getProperty("line.separator");
-   val lines = scala.io.Source.fromFile(new java.io.File("target/test/OutputTest.xml")).getLines().mkString(lineSep)
-
-   val expected = """<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="5.0">
- <file name="foo">
-  <error column="2" line="1" source="org.scalastyle.file.FileLengthChecker" severity="error" message="custom"></error>
-  <error column="4" line="3" source="org.scalastyle.file.FileLengthChecker" severity="error" message="custom 3"></error>
- </file>
- <file name="bar">
-  <error source="org.scalastyle.file.FileLengthChecker" severity="warning" message="barbar.message"></error>
-  <error source="org.scalastyle.file.FileLengthChecker" severity="info" message="bazbar.message"></error>
-  <error column="6" line="5" source="org.scalastyle.file.FileLengthChecker" severity="error" message="bazbaz"></error>
-  <error column="8" line="7" severity="error" message="noClass"></error>
- </file>
-</checkstyle>"""
-
-   assertEquals(expected, lines);
- }
-
- @Test def testXmlOutputCannotCreateFile(): Unit = {
-   val fooSpec = new FileSpec { def name: String = "foo" }
-   val barSpec = new FileSpec { def name: String = "bar" }
-
-   val messages = List(
-       StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(1), Some(2), Some("custom")),
-       StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(3), Some(4), Some("custom 3")),
-       StyleError(barSpec, classOf[FileLengthChecker], "barbar", WarningLevel, List[String](), None, None, None),
-       StyleError(barSpec, classOf[FileLengthChecker], "bazbar", InfoLevel, List[String](), None, None, None),
-       StyleException(barSpec, Some(classOf[FileLengthChecker]), "bazbaz", "stacktrace\nstacktrace", Some(5), Some(6)),
-       StyleException(barSpec, None, "noClass", "stacktrace\nstacktrace", Some(7), Some(8))
-   )
-
-   new java.io.File("target").mkdir();
-
-   try {
-       XmlOutput.save(ConfigFactory.load(), "target/does.not.exist/OutputTest.xml", "UTF-8", messages);
-   } catch {
-     case e: java.io.FileNotFoundException => // OK
-     case _: Throwable => fail("expected FileNotFoundException")
-   }
-
- }
+  @Test
+  @Ignore("doesn't work under 2.9")
+  def testXmlOutput(): Unit = {
+    val fooSpec = new FileSpec { def name: String = "foo" }
+    val barSpec = new FileSpec { def name: String = "bar" }
+ 
+    val messages = List(
+      StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(1), Some(2), Some("custom")),
+      StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(3), Some(4), Some("custom 3")),
+      StyleError(barSpec, classOf[FileLengthChecker], "barbar", WarningLevel, List[String](), None, None, None),
+      StyleError(barSpec, classOf[FileLengthChecker], "bazbar", InfoLevel, List[String](), None, None, None),
+      StyleException(barSpec, Some(classOf[FileLengthChecker]), "bazbaz", "stacktrace\nstacktrace", Some(5), Some(6)),
+      StyleException(barSpec, None, "noClass", "stacktrace\nstacktrace", Some(7), Some(8))
+    )
+ 
+    new java.io.File("target").mkdir()
+    new java.io.File("target/test").mkdir()
+ 
+    XmlOutput.save(ConfigFactory.load(), "target/test/OutputTest.xml", "UTF-8", messages)
+ 
+    val lineSep = System.getProperty("line.separator")
+    val lines = scala.io.Source.fromFile(new java.io.File("target/test/OutputTest.xml")).getLines().mkString(lineSep)
+ 
+    val expected = 
+    """
+      |<?xml version="1.0" encoding="UTF-8"?>
+      | <checkstyle version="5.0">
+      |  <file name="foo">
+      |   <error column="2" line="1" source="org.scalastyle.file.FileLengthChecker" severity="error" message="custom"></error>
+      |   <error column="4" line="3" source="org.scalastyle.file.FileLengthChecker" severity="error" message="custom 3"></error>
+      |  </file>
+      |  <file name="bar">
+      |   <error source="org.scalastyle.file.FileLengthChecker" severity="warning" message="barbar.message"></error>
+      |   <error source="org.scalastyle.file.FileLengthChecker" severity="info" message="bazbar.message"></error>
+      |   <error column="6" line="5" source="org.scalastyle.file.FileLengthChecker" severity="error" message="bazbaz"></error>
+      |   <error column="8" line="7" severity="error" message="noClass"></error>
+      |  </file>
+      | </checkstyle>
+    """.stripMargin
+ 
+    assertEquals(expected, lines)
+  }
+ 
+  @Test def testXmlOutputCannotCreateFile(): Unit = {
+    val fooSpec = new FileSpec { def name: String = "foo" }
+    val barSpec = new FileSpec { def name: String = "bar" }
+ 
+    val messages = List(
+      StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(1), Some(2), Some("custom")),
+      StyleError(fooSpec, classOf[FileLengthChecker], "foobar", ErrorLevel, List[String](), Some(3), Some(4), Some("custom 3")),
+      StyleError(barSpec, classOf[FileLengthChecker], "barbar", WarningLevel, List[String](), None, None, None),
+      StyleError(barSpec, classOf[FileLengthChecker], "bazbar", InfoLevel, List[String](), None, None, None),
+      StyleException(barSpec, Some(classOf[FileLengthChecker]), "bazbaz", "stacktrace\nstacktrace", Some(5), Some(6)),
+      StyleException(barSpec, None, "noClass", "stacktrace\nstacktrace", Some(7), Some(8))
+    )
+ 
+    new java.io.File("target").mkdir()
+ 
+    try {
+        XmlOutput.save(ConfigFactory.load(), "target/does.not.exist/OutputTest.xml", "UTF-8", messages)
+    } catch {
+      case e: java.io.FileNotFoundException => // OK
+      case _: Throwable => fail("expected FileNotFoundException")
+    }
+  }
 }

--- a/src/test/scala/org/scalastyle/ScalastyleConfigurationTest.scala
+++ b/src/test/scala/org/scalastyle/ScalastyleConfigurationTest.scala
@@ -44,15 +44,18 @@ class ScalastyleConfigurationTest extends AssertionsForJUnit {
   def clean(s: String): String = s.replace("\u000d", "")
 
   @Test def readXmlStringWithCustom(): Unit = {
-    val xml = """<scalastyle commentFilter="enabled">
-    <name>name</name>
- <check customId="custom.id" level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
-  </parameters>
-  <customMessage>customMessage</customMessage>
- </check>
-</scalastyle>"""
+    val xml =
+    """
+      |<scalastyle commentFilter="enabled">
+      |    <name>name</name>
+      | <check customId="custom.id" level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+      |  <parameters>
+      |   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+      |  </parameters>
+      |  <customMessage>customMessage</customMessage>
+      | </check>
+      |</scalastyle>
+    """.stripMargin
 
     val config = ScalastyleConfiguration.readFromString(xml)
 
@@ -72,10 +75,13 @@ class ScalastyleConfigurationTest extends AssertionsForJUnit {
   }
 
   @Test def readXmlString(): Unit = {
-    val xml = """<scalastyle>
-    <name>name</name>
- <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false"/>
-</scalastyle>"""
+    val xml =
+    """
+      |<scalastyle>
+      |    <name>name</name>
+      | <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false"/>
+      |</scalastyle>
+    """.stripMargin
 
     val config = ScalastyleConfiguration.readFromString(xml)
 

--- a/src/test/scala/org/scalastyle/StringInterpolationTest.scala
+++ b/src/test/scala/org/scalastyle/StringInterpolationTest.scala
@@ -32,13 +32,13 @@ class StringInterpolationTest extends CheckerTest {
 
   @Test def testOne(): Unit = {
     val source = """
-package foobar
-
-object Foobar {
-  val name = "Fred"
-  pfoorintln(s"Hello $name")
-}
-""";
+      |package foobar
+      |
+      |object Foobar {
+      |  val name = "Fred"
+      |  pfoorintln(s"Hello $name")
+      |}
+    """.stripMargin
 
     assertErrors(List(fileError(List("5"), message)), source, Map("maxFileLength" -> "5"), message, customId = Some("this.is.custom"))
   }

--- a/src/test/scala/org/scalastyle/file/FileLengthCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/FileLengthCheckerTest.scala
@@ -23,10 +23,10 @@ import org.scalastyle.Checker
 import org.scalastyle.StyleError
 import org.scalastyle.Message
 
-import java.util.Set;
+import java.util.Set
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Before
+import org.junit.Test
 
 // scalastyle:off multiple.string.literals
 
@@ -35,25 +35,27 @@ class FileLengthCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[FileLengthChecker]
 
   @Test def testZero(): Unit = {
-    val source = """
-package foobar
-
-  object Foobar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+    """.stripMargin.trim
 
     assertErrors(List(), source, Map("maxFileLength" -> "5"))
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-  object Foobar {
-}
-  object Barbar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+      |  object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(fileError(List("5"))), source, Map("maxFileLength" -> "5"))
   }

--- a/src/test/scala/org/scalastyle/file/FileLineLengthCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/FileLineLengthCheckerTest.scala
@@ -23,10 +23,10 @@ import org.scalastyle.Checker
 import org.scalastyle.StyleError
 import org.scalastyle.Message
 
-import java.util.Set;
+import java.util.Set
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Before
+import org.junit.Test
 
 // scalastyle:off magic.number multiple.string.literals
 
@@ -35,36 +35,39 @@ class FileLineLengthCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[FileLineLengthChecker]
 
   @Test def testNoMax(): Unit = {
-    val source = """
-package foobar
-
-    object Foobar {
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |    object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("maxLineLength" -> "20"))
   }
 
   @Test def testWithOneMax(): Unit = {
-    val source = """
-package foobar
-
-    object Foobar {
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |    object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(lineError(4, List("15"))), source, Map("maxLineLength" -> "15"))
   }
 
   @Test def testWithImports(): Unit = {
-    val source = """
-package foobar
-import org.scalastyle.file.SuperLongImportClass
-
-    object Foobar {
-      import org.scalastyle.file._
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |import org.scalastyle.file.SuperLongImportClass
+      |
+      |    object Foobar {
+      |      import org.scalastyle.file._
+      |}
+    """.stripMargin
 
     assertErrors(
       List(lineError(5, List("15"))),
@@ -79,26 +82,28 @@ import org.scalastyle.file.SuperLongImportClass
 
 
   @Test def testWithTwoMax(): Unit = {
-    val source = """
-package foobar
-
-    object Foobar {
-}
-    object Barbar {
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |    object Foobar {
+      |}
+      |    object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(lineError(4, List("15")), lineError(6, List("15"))), source, Map("maxLineLength" -> "15"))
   }
 
   @Test def testWithSpacesTabs(): Unit = {
-    val source = """
-package foobar
-
-import# #java.lang._
-object Barbar {
-}
-""".replaceAll("#","\t");
+    val source = 
+    """
+      |package foobar
+      |
+      |import# #java.lang._
+      |object Barbar {
+      |}
+    """.stripMargin.replaceAll("#","\t")
 
     assertErrors(List(lineError(4, List("14")), lineError(5, List("14"))), source, Map("maxLineLength" -> "14"))
   }

--- a/src/test/scala/org/scalastyle/file/FileTabCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/FileTabCheckerTest.scala
@@ -23,10 +23,10 @@ import org.scalastyle.Checker
 import org.scalastyle.StyleError
 import org.scalastyle.Message
 
-import java.util.Set;
+import java.util.Set
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Before
+import org.junit.Test
 
 // scalastyle:off magic.number multiple.string.literals
 
@@ -35,36 +35,39 @@ class FileTabCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[FileTabChecker]
 
   @Test def testZero(): Unit = {
-    val source = """
-package foobar
-
-    object Foobar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |    object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-#object Foobar {
-}
-""".replaceAll("#", "\t");
+    val source =
+    """
+      |package foobar
+      |
+      |#object Foobar {
+      |}
+    """.stripMargin.replaceAll("#", "\t")
 
     assertErrors(List(columnError(4, 0)), source)
   }
 
   @Test def testTwo(): Unit = {
-    val source = """
-package foobar
-
-#object Foobar {
-}
-#object Barbar {
-}
-""".replaceAll("#", "\t");
+    val source =
+    """
+      |package foobar
+      |
+      |#object Foobar {
+      |}
+      |#object Barbar {
+      |}
+    """.stripMargin.replaceAll("#", "\t")
 
     assertErrors(List(columnError(4, 0), columnError(6, 0)), source)
   }

--- a/src/test/scala/org/scalastyle/file/HeaderMatchesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/HeaderMatchesCheckerTest.scala
@@ -23,10 +23,10 @@ import org.scalastyle.Checker
 import org.scalastyle.StyleError
 import org.scalastyle.Message
 
-import java.util.Set;
+import java.util.Set
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Before
+import org.junit.Test
 
 // scalastyle:off magic.number multiple.string.literals
 
@@ -34,51 +34,59 @@ class HeaderMatchesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val key = "header.matches"
   val classUnderTest = classOf[HeaderMatchesChecker]
 
-  val licence = """/**
- * Copyright (C) 2009-2010 the original author or authors.
- * See the notice.md file distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */"""
+  val licence = 
+  """
+    |/**
+    | * Copyright (C) 2009-2010 the original author or authors.
+    | * See the notice.md file distributed with this work for additional
+    | * information regarding copyright ownership.
+    | *
+    | * Licensed under the Apache License, Version 2.0 (the "License");
+    | * you may not use this file except in compliance with the License.
+    | * You may obtain a copy of the License at
+    | *
+    | *     http://www.apache.org/licenses/LICENSE-2.0
+    | *
+    | * Unless required by applicable law or agreed to in writing, software
+    | * distributed under the License is distributed on an "AS IS" BASIS,
+    | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    | * See the License for the specific language governing permissions and
+    | * limitations under the License.
+    | */
+   """.stripMargin.trim
 
   @Test def testOK(): Unit = {
-    val source = licence + """
-package foobar
-
-  object Foobar {
-}
-""";
+    val source = licence + 
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("header" -> licence))
   }
 
   @Test def testKO(): Unit = {
-    val source = licence.replaceAll("BASIS,", "XXX") + """
-package foobar
-
-  object Foobar {
-}
-""";
+    val source = licence.replaceAll("BASIS,", "XXX") + 
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(lineError(13)), source, Map("header" -> licence))
   }
 
   @Test def testTooShort(): Unit = {
-    val source = """/**
- * Copyright (C) 2009-2010 the original author or authors.
- * See the notice.md file distributed with this work for additional
- * information regarding copyright ownership.""";
+    val source = 
+    """
+      |/**
+      | * Copyright (C) 2009-2010 the original author or authors.
+      | * See the notice.md file distributed with this work for additional
+      | * information regarding copyright ownership.
+    """.stripMargin.trim
 
     assertErrors(List(lineError(4)), source, Map("header" -> licence))
   }
@@ -93,34 +101,37 @@ package foobar
   }
 
   @Test def testRegexOK(): Unit = {
-    val source = licence + """
-package foobar
-
-  object Foobar {
-}
-"""
+    val source = licence + 
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("header" -> licenceRegex, "regex" -> "true"))
   }
 
   @Test def testRegexFlexible(): Unit = {
-    val source = licence.replace("2009-2010", "2009-2014") + """
-package foobar
-
-  object Foobar {
-}
-"""
+    val source = licence.replace("2009-2010", "2009-2014") + 
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("header" -> licenceRegex, "regex" -> "true"))
   }
 
   @Test def testRegexKO(): Unit = {
-    val source = licence.replace("2009-2010", "xxxx-xxxx") + """
-package foobar
-
-  object Foobar {
-}
-"""
+    val source = licence.replace("2009-2010", "xxxx-xxxx") + 
+    """
+      |package foobar
+      |
+      |  object Foobar {
+      |}
+    """.stripMargin
 
     assertErrors(List(fileError()), source, Map("header" -> licenceRegex, "regex" -> "true"))
   }

--- a/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/IndentationCheckerTest.scala
@@ -16,7 +16,7 @@
 
 package org.scalastyle.file
 
-import org.junit.Test;
+import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 
 // scalastyle:off magic.number
@@ -26,67 +26,68 @@ class IndentationCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[IndentationChecker]
 
   val cleanSource =
-"""
-/**
- * Scaladoc comments should pass
- */
-class A {
-  val foo = 1
-  def bar(a: String) = {
-    a.length
-  }
-}
+  """
+    |/**
+    | * Scaladoc comments should pass
+    | */
+    |class A {
+    |  val foo = 1
+    |  def bar(a: String) = {
+    |    a.length
+    |  }
+    |}
+    |
+    |class B(
+    |    paramDoubleIndent: Boolean,
+    |    isAlsoOk: Boolean)
+    |  extends A
+    |{
+    |  override val foo = 2
+    |  val foobar =
+    |    Seq(
+    |      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    |      "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    |      "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+    |    )
+    |
+    |  def methodWithMultilineParams(
+    |    paramDoubleIndent: Boolean,
+    |    isAlsoOk: Boolean): Unit = {}
+    |}
+  """.stripMargin
 
-class B(
-    paramDoubleIndent: Boolean,
-    isAlsoOk: Boolean)
-  extends A
-{
-  override val foo = 2
-  val foobar =
-    Seq(
-      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-      "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
-    )
-
-  def methodWithMultilineParams(
-    paramDoubleIndent: Boolean,
-    isAlsoOk: Boolean): Unit = {}
-}
-"""
   @Test def testNoErrorsDefaultTabSize(): Unit = {
     assertErrors(List(), cleanSource)
   }
 
   @Test def forExpression(): Unit = {
     val source =
-"""
-val id = 50
-for {
-  a <- findA(id)
-  b =  a.b
-  c <- b.cs
-  if c.isEven
-} yield c
-"""
+    """
+      |val id = 50
+      |for {
+      |  a <- findA(id)
+      |  b =  a.b
+      |  c <- b.cs
+      |  if c.isEven
+      |} yield c
+    """.stripMargin
 
     assertErrors(Nil, source)
   }
 
   @Test def dsl(): Unit = {
     val source =
-"""
-  |val id = 123
-  |val (m, g) = (GroupMember.syntax("m"), Group.syntax("g"))
-  |val groupMember = withSQL {
-  |  select
-  |    .from(GroupMember as m)
-  |    .leftJoin(Group as g)
-  |    .on(m.groupId, g.id)
-  |    .where.eq(m.id, id)
-  |}.map(GroupMember(m, g)).single.apply()
-""".stripMargin
+    """
+      |val id = 123
+      |val (m, g) = (GroupMember.syntax("m"), Group.syntax("g"))
+      |val groupMember = withSQL {
+      |  select
+      |    .from(GroupMember as m)
+      |    .leftJoin(Group as g)
+      |    .on(m.groupId, g.id)
+      |    .where.eq(m.id, id)
+      |}.map(GroupMember(m, g)).single.apply()
+    """.stripMargin
 
     assertErrors(Nil, source)
   }
@@ -104,14 +105,15 @@ for {
 
   @Test def testErrorsIncorrectTabSize(): Unit = {
     val source =
-"""
-class A {
- val foo = 1
-   def bar(a: String) = {
-    a.length
-  }
-}
-"""
+    """
+      |class A {
+      | val foo = 1
+      |   def bar(a: String) = {
+      |    a.length
+      |  }
+      |}
+    """.stripMargin
+
     assertErrors(List(lineError(3), lineError(4)), source)
   }
 

--- a/src/test/scala/org/scalastyle/file/NewLineAtEofCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/NewLineAtEofCheckerTest.scala
@@ -22,10 +22,10 @@ import org.junit.Assert.assertTrue
 import org.scalastyle.Checker
 import org.scalastyle.StyleError
 import org.scalastyle.Message
-import java.util.Set;
+import java.util.Set
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Before
+import org.junit.Test
 
 // scalastyle:off magic.number multiple.string.literals
 
@@ -34,11 +34,13 @@ class NoNewLineAtEofFileCheckerTest extends AssertionsForJUnit with CheckerTest 
   val classUnderTest = classOf[NoNewLineAtEofChecker]
 
   @Test def testNoNewLine(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-}#""";
+    val source = 
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |}#
+    """.stripMargin.trim
 
     assertErrors(List(fileError()), source.replace('#', '\n'))
     assertErrors(List(fileError()), source.replace('#', '\r'))
@@ -51,11 +53,13 @@ class NewLineAtEofFileCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[NewLineAtEofChecker]
 
   @Test def testRequireNewLineTrue(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-}#""";
+    val source = 
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |}#
+    """.stripMargin.trim
 
     assertErrors(List(), source.replace('#', '\n'))
     assertErrors(List(), source.replace('#', '\r'))

--- a/src/test/scala/org/scalastyle/file/RegexCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/RegexCheckerTest.scala
@@ -25,21 +25,23 @@ class RegexCheckerTest extends AssertionsForJUnit with CheckerTest {
   val key = "regex"
   val classUnderTest = classOf[RegexChecker]
 
-  private val source = """//
-package foobar
-
-
-class foobar {
-
-  def aMethod: String = {
-    println("should be caught")
-    // println("should not")
-    ("SHOULD NOT BE HERE")
-    "TEST STRING";
-  }
-
-}
-"""
+  private val source = 
+  """
+    |//
+    |package foobar
+    |
+    |
+    |class foobar {
+    |
+    |  def aMethod: String = {
+    |    println("should be caught")
+    |    // println("should not")
+    |    ("SHOULD NOT BE HERE")
+    |    "TEST STRING";
+    |  }
+    |
+    |}
+  """.stripMargin.trim
 
   @Test
   def testSimpleCheck(): Unit = {

--- a/src/test/scala/org/scalastyle/file/WhitespaceEndOfLineCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/WhitespaceEndOfLineCheckerTest.scala
@@ -22,10 +22,10 @@ import org.junit.Assert.assertTrue
 import org.scalastyle.Checker
 import org.scalastyle.StyleError
 import org.scalastyle.Message
-import java.util.Set;
+import java.util.Set
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Before
+import org.junit.Test
 
 // scalastyle:off magic.number multiple.string.literals
 
@@ -35,33 +35,33 @@ class WhitespaceEndOfLineCheckerTest extends AssertionsForJUnit with CheckerTest
 
   @Test def testZero(): Unit = {
     val source = """
-package foobar
-
-object Foobar {
-}
-""";
+      |package foobar
+      |
+      |object Foobar {
+      |}
+      |""".stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
     val source = """
-package foobar##
-
-object Foobar {
-}
-""".replaceAll("#", " ");
+      |package foobar##
+      |
+      |object Foobar {
+      |}
+      |""".stripMargin.replaceAll("#", " ")
 
     assertErrors(List(columnError(2, 14)), source)
   }
 
   @Test def testTwo(): Unit = {
     val source = """
-package foobar~
-class  foobar#
-object Foobar {
-}
-""".replaceAll("~", " ").replaceAll("#", "\t");
+      |package foobar~
+      |class  foobar#
+      |object Foobar {
+      |}
+      |""".stripMargin.replaceAll("~", " ").replaceAll("#", "\t")
 
     assertErrors(List(columnError(2, 14), columnError(3, 13)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/BlockImportCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/BlockImportCheckerTest.scala
@@ -29,73 +29,91 @@ class BlockImportCheckerTest extends AssertionsForJUnit with CheckerTest {
 
   @Test
   def singleImportIsNoBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable.Buffer
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.Buffer
+    """.stripMargin
+
     assertErrors(Nil, source)
   }
 
   @Test
   def importAllIsNoBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable._
-      """
+    val source = 
+    """
+      |import scala.collection.mutable._
+    """.stripMargin
+
     assertErrors(Nil, source)
   }
 
   @Test
   def hideImportIsNoBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable.{Buffer => _}
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.{Buffer => _}
+    """.stripMargin
+
     assertErrors(Nil, source)
   }
 
   @Test
   def renameImportIsNoBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable.{Buffer => MB}
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.{Buffer => MB}
+    """.stripMargin
+
     assertErrors(Nil, source)
   }
 
   @Test
   def commaSeparatedImportIsBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable, mutable.Buffer, mutable.ArrayBuffer
-      """
+    val source = 
+    """
+      |import scala.collection.mutable, mutable.Buffer, mutable.ArrayBuffer
+    """.stripMargin
+
     assertErrors(List(columnError(2, 7)), source)
   }
 
   @Test
   def blockImportFound(): Unit = {
-    val source = """
-import scala.collection.mutable.{Buffer, ArrayBuffer}
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.{Buffer, ArrayBuffer}
+    """.stripMargin
+
     assertErrors(List(columnError(2, 7)), source)
   }
 
   @Test
   def wildcardImportAfterRenameImportsIsNoBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable.{Buffer => MB, ArrayBuffer => _, _}
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.{Buffer => MB, ArrayBuffer => _, _}
+    """.stripMargin
+
     assertErrors(Nil, source)
   }
 
   @Test
   def wildcardImportAfterNormalImportAndRenameImportIsBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable.{Buffer => MB, ArrayBuffer, _}
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.{Buffer => MB, ArrayBuffer, _}
+    """.stripMargin
+
     assertErrors(List(columnError(2, 7)), source)
   }
 
   @Test
   def wildcardImportAfterNormalImportIsBlockImport(): Unit = {
-    val source = """
-import scala.collection.mutable.{ArrayBuffer, _}
-      """
+    val source = 
+    """
+      |import scala.collection.mutable.{ArrayBuffer, _}
+    """.stripMargin
+
     assertErrors(List(columnError(2, 7)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/ClassCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassCheckerTest.scala
@@ -33,36 +33,38 @@ class EmptyClassCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[EmptyClassChecker]
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-class Foobar1 {}
-class Foobar2 { /* foobar */ }
-class Foobar3 {
-      // foobar
-}
-class Foobar4 { }
-class Foobar5 {
-}
-class Foobar6 {
-  def foobar() = 4
-}
-class Foobar7
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar1 {}
+      |class Foobar2 { /* foobar */ }
+      |class Foobar3 {
+      |      // foobar
+      |}
+      |class Foobar4 { }
+      |class Foobar5 {
+      |}
+      |class Foobar6 {
+      |  def foobar() = 4
+      |}
+      |class Foobar7
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6), columnError(5, 6), columnError(6, 6), columnError(9, 6), columnError(10, 6)), source)
   }
 
   @Test def testInnerClass(): Unit = {
-    val source = """
-package foobar
-
-class Outer {
-  class Foobar1
-  class Foobar2 {}
-  trait Barbar {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Outer {
+      |  class Foobar1
+      |  class Foobar2 {}
+      |  trait Barbar {}
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 8), columnError(7, 8)), source)
   }
@@ -73,46 +75,50 @@ class ClassTypeParameterCheckerTest extends AssertionsForJUnit with CheckerTest 
   val classUnderTest = classOf[ClassTypeParameterChecker]
 
   @Test def testClass(): Unit = {
-    val source = """
-package foobar
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar1
+      |class Foobar2[T]
+      |class Foobar3[Foo] {
+      |  def foo = 4
+      |}
+      |class Foobar4[Foo[T]] {
+      |  def foo = 4
+      |}
+      |class Foobar5[+T]
+      |class Foobar6[T <: Any]
+      |class Foobar7[List[T], List[Foo], List[T]]
+      |class Foobar8[List[T], List[T], List[Foo]]
+      |class Foobar9[Foo <: Any]
+      |class Foobar0[+Foo]
+    """.stripMargin
 
-class Foobar1
-class Foobar2[T]
-class Foobar3[Foo] {
-  def foo = 4
-}
-class Foobar4[Foo[T]] {
-  def foo = 4
-}
-class Foobar5[+T]
-class Foobar6[T <: Any]
-class Foobar7[List[T], List[Foo], List[T]]
-class Foobar8[List[T], List[T], List[Foo]]
-class Foobar9[Foo <: Any]
-class Foobar0[+Foo]
-"""
     assertErrors(List(columnError(6, 6), columnError(14, 6), columnError(15, 6), columnError(16, 6), columnError(17, 6)), source, Map("regex" -> "^[A-Z]$"))
   }
 
   @Test def testTrait(): Unit = {
-    val source = """
-package foobar
+    val source =
+    """
+      |package foobar
+      |
+      |trait Foobar1
+      |trait Foobar2[T]
+      |trait Foobar3[Foo] {
+      |  def foo = 4
+      |}
+      |trait Foobar4[Foo[T]] {
+      |  def foo = 4
+      |}
+      |trait Foobar5[+T]
+      |trait Foobar6[T <: Any]
+      |trait Foobar7[List[T], List[Foo], List[T]]
+      |trait Foobar8[List[T], List[T], List[Foo]]
+      |trait Foobar9[Foo <: Any]
+      |trait Foobar0[+Foo]
+    """.stripMargin
 
-trait Foobar1
-trait Foobar2[T]
-trait Foobar3[Foo] {
-  def foo = 4
-}
-trait Foobar4[Foo[T]] {
-  def foo = 4
-}
-trait Foobar5[+T]
-trait Foobar6[T <: Any]
-trait Foobar7[List[T], List[Foo], List[T]]
-trait Foobar8[List[T], List[T], List[Foo]]
-trait Foobar9[Foo <: Any]
-trait Foobar0[+Foo]
-"""
     assertErrors(List(columnError(6, 6), columnError(14, 6), columnError(15, 6), columnError(16, 6), columnError(17, 6)), source, Map("regex" -> "^[A-Z]$"))
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
@@ -28,26 +28,28 @@ class ClassNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[ClassNamesChecker]
 
   @Test def testZero(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  val foo = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  val foo = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-class foobar {
-  class barbar {
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class foobar {
+      |  class barbar {
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6, List("^[A-Z][A-Za-z]*$")), columnError(5, 8, List("^[A-Z][A-Za-z]*$"))), source)
   }
@@ -58,39 +60,42 @@ class ObjectNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[ObjectNamesChecker]
 
   @Test def testZero(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-object foobar {
-  object barbar {
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object foobar {
+      |  object barbar {
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 7, List("^[A-Z][A-Za-z]*$")), columnError(5, 9, List("^[A-Z][A-Za-z]*$"))), source)
   }
 
   @Test def testPackageObject(): Unit = {
-    val source = """
-package foobar
-
-package object foobar {
-  object barbar {
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |package object foobar {
+      |  object barbar {
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 9, List("^[A-Z][A-Za-z]*$"))), source)
   }
@@ -102,79 +107,88 @@ class PackageNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[PackageNamesChecker]
 
   @Test def testSinglePartNoError(): Unit = {
-    val source = """
-package foobar
-""";
+    val source =
+    """
+      |package foobar
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testSinglePartError(): Unit = {
-    val source = """
-package FooBar
-""";
+    val source =
+    """
+      |package FooBar
+    """.stripMargin
 
     assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$"))), source)
   }
 
   @Test def testMultiPartNoError(): Unit = {
-    val source = """
-package abc.foobar
-""";
+    val source =
+    """
+      |package abc.foobar
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testMultiPartError(): Unit = {
-    val source = """
-package abc.foo_bar
-""";
+    val source =
+    """
+      |package abc.foo_bar
+    """.stripMargin
 
     assertErrors(List(columnError(2, 12, List("^[a-z][A-Za-z]*$"))), source)
   }
 
   @Test def testPackageObjectNoError(): Unit = {
-    val source = """
-package object _foo_bar
-""";
+    val source =
+    """
+      |package object _foo_bar
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   // Check case where the package name is built up by successive package statements.
   @Test def testMultiLinePackageNoError(): Unit = {
-    val source = """
-package foo
-package bar
-""";
+    val source =
+    """
+      |package foo
+      |package bar
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   // Check case where the package name is built up by successive package statements.
   @Test def testMultiLinePackageError(): Unit = {
-    val source = """
-package foo
-package Bar
-""";
+    val source =
+    """
+      |package foo
+      |package Bar
+    """.stripMargin
 
     assertErrors(List(columnError(3, 8, List("^[a-z][A-Za-z]*$"))), source)
   }
 
   @Test def testMultiLinePackageMultipleError(): Unit = {
-    val source = """
-package Foo
-package Bar
-""";
+    val source =
+    """
+      |package Foo
+      |package Bar
+    """.stripMargin
 
     assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$")), columnError(3, 8, List("^[a-z][A-Za-z]*$"))), source)
   }
 
   @Test def testPackageAndPackageObjectNoError(): Unit = {
-    val source = """
-package org.thisone
-package object _foo
-""";
+    val source =
+    """
+      |package org.thisone
+      |package object _foo
+    """.stripMargin
 
     assertErrors(List(), source)
   }
@@ -186,39 +200,42 @@ class PackageObjectNamesCheckerTest extends AssertionsForJUnit with CheckerTest 
   val classUnderTest = classOf[PackageObjectNamesChecker]
 
   @Test def testZero(): Unit = {
-    val source = """
-package foobar
-
-package object foobar {
-  val foo = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |package object foobar {
+      |  val foo = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-package object Foobar {
-}
-package object Barbar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |package object Foobar {
+      |}
+      |package object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 15, List("^[a-z][A-Za-z]*$")), columnError(6, 15, List("^[a-z][A-Za-z]*$"))), source)
   }
 
   @Test def testPackageObject(): Unit = {
-    val source = """
-package foobar
-
-object foobar {
-  object barbar {
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object foobar {
+      |  object barbar {
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
@@ -229,66 +246,70 @@ class MethodNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[MethodNamesChecker]
 
   @Test def testDefault(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  def foo() = 1
-  def +() = 1
-//  def foo+() = 1
-  def setting_=(s: Boolean) {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  def foo() = 1
+      |  def +() = 1
+      |//  def foo+() = 1
+      |  def setting_=(s: Boolean) {}
+      |}
+    """.stripMargin
 
     assertErrors(List(defErr(6, 6)), source)
   }
 
   @Test def testNonDefault(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  def Foo() = 1
-  def +() = 1
-//  def Foo+() = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  def Foo() = 1
+      |  def +() = 1
+      |//  def Foo+() = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 6, List("^F[o*]*$"))), source, Map("regex" -> "^F[o*]*$"))
   }
 
   @Test def testWithIgnoreRegex(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  def foo() = 1
-  def +() = 1
-  def -() = 1
-//  def Foo+() = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  def foo() = 1
+      |  def +() = 1
+      |  def -() = 1
+      |//  def Foo+() = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(defErr(7, 6)), source, Map("ignoreRegex" -> "^\\+$"))
   }
 
   @Test def testIgnoreOverride(): Unit = {
-    val source = """
-package foobar
-
-trait Bar {
-  def +() = 1
-  def -() = 1
-  def &() = 1
-}
-
-class Foobar extends Bar {
-  override def +() = 1
-  protected override def &() = 1
-  override protected def -() = 1
-  def bar() = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |trait Bar {
+      |  def +() = 1
+      |  def -() = 1
+      |  def &() = 1
+      |}
+      |
+      |class Foobar extends Bar {
+      |  override def +() = 1
+      |  protected override def &() = 1
+      |  override protected def -() = 1
+      |  def bar() = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(defErr(5, 6), defErr(6, 6), defErr(7, 6)), source, Map("ignoreOverride" -> "true"))
   }

--- a/src/test/scala/org/scalastyle/scalariform/CommentFilterTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/CommentFilterTest.scala
@@ -27,48 +27,50 @@ class CommentFilterTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[ClassNamesChecker]
 
   @Test def testOnOff(): Unit = {
-    val source = """
-package foobar
-
-class foobar {
-  // scalastyle:off
-  class barbar { }
-  // scalastyle:on
-  // scalastyle:off class.name
-  class bazbaz {}
-  // scalastyle:on class.name
-
-  // scalastyle:off object.name
-  val s = " // scalastyle:off "
-  class g { }
-}
-"""
+    val source = 
+    """
+      |package foobar
+      |
+      |class foobar {
+      |  // scalastyle:off
+      |  class barbar { }
+      |  // scalastyle:on
+      |  // scalastyle:off class.name
+      |  class bazbaz {}
+      |  // scalastyle:on class.name
+      |
+      |  // scalastyle:off object.name
+      |  val s = " // scalastyle:off "
+      |  class g { }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6, List("^[A-Z][A-Za-z]*$")), columnError(14, 8, List("^[A-Z][A-Za-z]*$"))), source)
   }
 
   @Test def testOnOffIgnore(): Unit = {
-    val source = """
-package foobar
-
-class foobar {
-  // scalastyle:on class.name
-  class barbar1 { } // scalastyle:ignore class.name
-  //
-
-  // scalastyle:on
-  class barbar2 { } // scalastyle:ignore
-  // scalastyle:off
-
-  // scalastyle:on
-  class barbar3 { } // scalastyle:ignore class.name
-  // scalastyle:off
-
-  // scalastyle:on
-  class barbar4 { } // scalastyle:ignore magic.number
-  // scalastyle:off
-}
-"""
+    val source = 
+    """
+      |package foobar
+      |
+      |class foobar {
+      |  // scalastyle:on class.name
+      |  class barbar1 { } // scalastyle:ignore class.name
+      |  //
+      |
+      |  // scalastyle:on
+      |  class barbar2 { } // scalastyle:ignore
+      |  // scalastyle:off
+      |
+      |  // scalastyle:on
+      |  class barbar3 { } // scalastyle:ignore class.name
+      |  // scalastyle:off
+      |
+      |  // scalastyle:on
+      |  class barbar4 { } // scalastyle:ignore magic.number
+      |  // scalastyle:off
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6, List("^[A-Z][A-Za-z]*$")), columnError(18, 8, List("^[A-Z][A-Za-z]*$"))), source)
   }
@@ -80,15 +82,15 @@ class CommentFilterMagicNumberTest extends AssertionsForJUnit with CheckerTest {
 
   @Test def testMagicNumberFilter(): Unit = {
     val source =
-      """
-package foobar
-
-object Foo {
-  f(77) // scalastyle:ignore
-  f(88)
-  f(99)
-}
-"""
+    """
+      |package foobar
+      |
+      |object Foo {
+      |  f(77) // scalastyle:ignore
+      |  f(88)
+      |  f(99)
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 4, List()), columnError(7, 4, List())), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/CovariantEqualsCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/CovariantEqualsCheckerTest.scala
@@ -33,51 +33,55 @@ class CovariantEqualsCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[CovariantEqualsChecker]
 
   @Test def testClassOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def equals(o: java.lang.Object): Boolean = false
-  def equals(o: java.lang.Integer): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def equals(o: java.lang.Object): Boolean = false
+      |  def equals(o: java.lang.Integer): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testClassCovariantEqualsNoObjectKO(): Unit = {
-    val source = """
-package foobar
-
-class CovariantEqualsNoObjectKO {
-  def equals(o: java.lang.Integer): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class CovariantEqualsNoObjectKO {
+      |  def equals(o: java.lang.Integer): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testObjectOK(): Unit = {
-    val source = """
-package foobar
-
-object OK {
-  def equals(o: java.lang.Object): Boolean = false
-  def equals(o: java.lang.Integer): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object OK {
+      |  def equals(o: java.lang.Object): Boolean = false
+      |  def equals(o: java.lang.Integer): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testObjectCovariantEqualsNoObjectKO(): Unit = {
-    val source = """
-package foobar
-
-object CovariantEqualsNoObjectKO {
-  def equals(o: java.lang.Integer): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object CovariantEqualsNoObjectKO {
+      |  def equals(o: java.lang.Integer): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 7)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/CyclomaticComplexityCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/CyclomaticComplexityCheckerTest.scala
@@ -27,130 +27,133 @@ class CyclomaticComplexityCheckerTest extends AssertionsForJUnit with CheckerTes
   val classUnderTest = classOf[CyclomaticComplexityChecker]
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  def foobar(i: Int): Int = {
-    if (i == 1) {
-      5
-    } else if (i == 2) {
-      true && false || true
-      5 match {
-        case 4 =>
-        case 5 =>
-        case _ =>
-      }
-    } else {
-      var f = 0
-      while (f > 0) {}
-      do {} while (f > 0)
-      for (t <- List())
-      3
-    }
-  }
-
-  def barbar(i: Int): Int = {
-    if (i == 1) {
-      5
-    } else if (i == 2) {
-      true && false || true
-      5 match {
-        case 4 =>
-        case 5 =>
-        case _ =>
-      }
-    } else {
-      var f = 0
-      while (f > 0) {}
-      do {} while (f > 0)
-      for (t <- List())
-      3
-    }
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  def foobar(i: Int): Int = {
+      |    if (i == 1) {
+      |      5
+      |    } else if (i == 2) {
+      |      true && false || true
+      |      5 match {
+      |        case 4 =>
+      |        case 5 =>
+      |        case _ =>
+      |      }
+      |    } else {
+      |      var f = 0
+      |      while (f > 0) {}
+      |      do {} while (f > 0)
+      |      for (t <- List())
+      |      3
+      |    }
+      |  }
+      |
+      |  def barbar(i: Int): Int = {
+      |    if (i == 1) {
+      |      5
+      |    } else if (i == 2) {
+      |      true && false || true
+      |      5 match {
+      |        case 4 =>
+      |        case 5 =>
+      |        case _ =>
+      |      }
+      |    } else {
+      |      var f = 0
+      |      while (f > 0) {}
+      |      do {} while (f > 0)
+      |      for (t <- List())
+      |      3
+      |    }
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6, List("12", "11")), columnError(24, 6, List("12", "11"))), source, Map("maximum" -> "11"))
   }
 
   @Test def testEmbeddedMethods(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  def foobar(i: Int): Int = {
-    // 1 for method, 2 for inner methods and 3 for if/elseif clause
-    def bar1(i: Int) = if (i == 1) 1 else 2
-    def bar2(i: Int) = if (i == 2) 1 else 2
-
-    if (i == 1) {
-      1
-    } else if (i == 2) {
-      2
-    } else if (i == 3) {
-      3
-    } else {
-      4
-    }
-  }
-
-  def barbar(i: Int): Int = {
-    // 1 for method, 2 for inner methods and 3 for if/elseif clause
-    def bar1(i: Int) = {
-      if (i == 1) {
-        1
-      } else if (i == 2) {
-        2
-      } else if (i == 3) {
-        3
-      } else {
-        4
-      }
-    }
-
-  }
-}
-"""
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  def foobar(i: Int): Int = {
+      |    // 1 for method, 2 for inner methods and 3 for if/elseif clause
+      |    def bar1(i: Int) = if (i == 1) 1 else 2
+      |    def bar2(i: Int) = if (i == 2) 1 else 2
+      |
+      |    if (i == 1) {
+      |      1
+      |    } else if (i == 2) {
+      |      2
+      |    } else if (i == 3) {
+      |      3
+      |    } else {
+      |      4
+      |    }
+      |  }
+      |
+      |  def barbar(i: Int): Int = {
+      |    // 1 for method, 2 for inner methods and 3 for if/elseif clause
+      |    def bar1(i: Int) = {
+      |      if (i == 1) {
+      |        1
+      |      } else if (i == 2) {
+      |        2
+      |      } else if (i == 3) {
+      |        3
+      |      } else {
+      |        4
+      |      }
+      |    }
+      |
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6, List("4", "3")), columnError(21, 6, List("4", "3"))), source, Map("maximum" -> "3"))
   }
 
   @Test def testEmbeddedClasses(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  // This is not caught by the checker. Don't know whether it should or not.
-  val f = if (i == 1) {
-    1
-  } else if (i == 2) {
-    2
-  } else if (i == 3) {
-    3
-  } else {
-    4
-  }
-
-  def foobar(i: Int): Int = {
-    // 1 for method, 2 for inner methods and 3 for if/elseif clause
-    class Foo2 {
-      def bar1(i: Int) = if (i == 1) 1 else 2
-      def bar2(i: Int) = if (i == 2) 1 else 2
-    }
-
-    if (i == 1) {
-      1
-    } else if (i == 2) {
-      2
-    } else if (i == 3) {
-      3
-    } else {
-      4
-    }
-  }
-}
-"""
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  // This is not caught by the checker. Don't know whether it should or not.
+      |  val f = if (i == 1) {
+      |    1
+      |  } else if (i == 2) {
+      |    2
+      |  } else if (i == 3) {
+      |    3
+      |  } else {
+      |    4
+      |  }
+      |
+      |  def foobar(i: Int): Int = {
+      |    // 1 for method, 2 for inner methods and 3 for if/elseif clause
+      |    class Foo2 {
+      |      def bar1(i: Int) = if (i == 1) 1 else 2
+      |      def bar2(i: Int) = if (i == 2) 1 else 2
+      |    }
+      |
+      |    if (i == 1) {
+      |      1
+      |    } else if (i == 2) {
+      |      2
+      |    } else if (i == 3) {
+      |      3
+      |    } else {
+      |      4
+      |    }
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(16, 6, List("4", "3"))), source, Map("maximum" -> "3"))
   }

--- a/src/test/scala/org/scalastyle/scalariform/DeprecatedJavaCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/DeprecatedJavaCheckerTest.scala
@@ -33,26 +33,27 @@ class DeprecatedJavaCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[DeprecatedJavaChecker]
 
   @Test def testClassOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  @Deprecated
-  def noparameters(): Any = null
-
-  @Deprecated("foobar")
-  def parameters(): Any = null
-
-  @java.lang.Deprecated
-  def noparametersFull(): Any = null
-
-  @java.lang.Deprecated("foobar")
-  def parametersFull(): Any = null
-
-  @deprecated
-  def ok(): Any = null
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  @Deprecated
+      |  def noparameters(): Any = null
+      |
+      |  @Deprecated("foobar")
+      |  def parameters(): Any = null
+      |
+      |  @java.lang.Deprecated
+      |  def noparametersFull(): Any = null
+      |
+      |  @java.lang.Deprecated("foobar")
+      |  def parametersFull(): Any = null
+      |
+      |  @deprecated
+      |  def ok(): Any = null
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 2), columnError(8, 2), columnError(11, 2), columnError(14, 2)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/EqualsHashCodeCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/EqualsHashCodeCheckerTest.scala
@@ -33,136 +33,146 @@ class EqualsHashCodeCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[EqualsHashCodeChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def hashCode(): Int = 45
-  def equals(o: java.lang.Object): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def hashCode(): Int = 45
+      |  def equals(o: java.lang.Object): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testHashCodeOnlyKO(): Unit = {
-    val source = """
-package foobar
-
-class HashCodeOnlyKO {
-  def hashCode(): Int = 45
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class HashCodeOnlyKO {
+      |  def hashCode(): Int = 45
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testEqualsOnlyKO(): Unit = {
-    val source = """
-package foobar
-
-class EqualsOnlyKO {
-  def equals(o: java.lang.Object): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class EqualsOnlyKO {
+      |  def equals(o: java.lang.Object): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testEqualsOnlyAnyKO(): Unit = {
-    val source = """
-package foobar
-
-class EqualsOnlyKO {
-  def equals(o: Any): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class EqualsOnlyKO {
+      |  def equals(o: Any): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testEqualsWrongSignatureOK(): Unit = {
-    val source = """
-package foobar
-
-class EqualsWrongSignatureOK {
-  def equals(o: scala.Object): Boolean = false
-  def equals(o: java.lang.Object)(o2: java.lang.Object): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class EqualsWrongSignatureOK {
+      |  def equals(o: scala.Object): Boolean = false
+      |  def equals(o: java.lang.Object)(o2: java.lang.Object): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testHashCodeWrongSignatureOK(): Unit = {
-    val source = """
-package foobar
-
-class HashCodeWrongSignatureOK {
-  def hashCode(o: scala.Object): Int = 45
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class HashCodeWrongSignatureOK {
+      |  def hashCode(o: scala.Object): Int = 45
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOuterKOInnerKO(): Unit = {
-    val source = """
-package foobar
-
-class OuterKO {
-  def hashCode(): Int = 45
-  class InnerKO {
-    def equals(o: java.lang.Object): Boolean = false
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OuterKO {
+      |  def hashCode(): Int = 45
+      |  class InnerKO {
+      |    def equals(o: java.lang.Object): Boolean = false
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6), columnError(6, 8)), source)
   }
 
   @Test def testOuterOKInnerKO(): Unit = {
-    val source = """
-package foobar
-
-class OuterOK {
-  def hashCode(): Int = 45
-  class InnerKO {
-    def equals(o: java.lang.Object): Boolean = false
-  }
-  def equals(o: java.lang.Object): Boolean = false
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OuterOK {
+      |  def hashCode(): Int = 45
+      |  class InnerKO {
+      |    def equals(o: java.lang.Object): Boolean = false
+      |  }
+      |  def equals(o: java.lang.Object): Boolean = false
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 8)), source)
   }
 
   @Test def testObjectInnerKO(): Unit = {
-    val source = """
-package foobar
-
-object Object {
-  class ObjectInnerKO {
-    def equals(o: java.lang.Object): Boolean = false
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Object {
+      |  class ObjectInnerKO {
+      |    def equals(o: java.lang.Object): Boolean = false
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 8)), source)
   }
 
   @Test def testMultipleClasses(): Unit = {
-    val source = """
-package foobar
-
-class Class1 {
-  def hashCode(): Int = 45
-}
-
-class Class2 {
-  def hashCode(): Int = 45
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Class1 {
+      |  def hashCode(): Int = 45
+      |}
+      |
+      |class Class2 {
+      |  def hashCode(): Int = 45
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6), columnError(8, 6)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/ForBraceCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ForBraceCheckerTest.scala
@@ -33,14 +33,15 @@ class ForBraceCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[ForBraceChecker]
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  for ( t <- List(1,2,3)) yield t
-  for { t <- List(1,2,3)} yield t
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  for ( t <- List(1,2,3)) yield t
+      |  for { t <- List(1,2,3)} yield t
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/IfBraceCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/IfBraceCheckerTest.scala
@@ -33,100 +33,105 @@ class IfBraceCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[IfBraceChecker]
 
   @Test def testDefault(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  val foo0 = if (true) "yes" else "no"
-  val foo1 = if (true)
-                 "yes"
-                 else
-                 "no"
-  val foo2 = if (true) { "yes" } else { "no" }
-  val foo3 = if (true) {
-                 "yes"
-                 } else {
-                 "no"
-                 }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  val foo0 = if (true) "yes" else "no"
+      |  val foo1 = if (true)
+      |                 "yes"
+      |                 else
+      |                 "no"
+      |  val foo2 = if (true) { "yes" } else { "no" }
+      |  val foo3 = if (true) {
+      |                 "yes"
+      |                 } else {
+      |                 "no"
+      |                 }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 13)), source)
   }
 
   @Test def testDefault2(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  val foo4 = if (true) "yes"
-                 else "no"
-  val foo5 = if (true) "yes"
-  val foo6 = if (true)
-                "yes"
-  val foo7 = if (true)
-                !false
-             else
-                !true
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  val foo4 = if (true) "yes"
+      |                 else "no"
+      |  val foo5 = if (true) "yes"
+      |  val foo6 = if (true)
+      |                "yes"
+      |  val foo7 = if (true)
+      |                !false
+      |             else
+      |                !true
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(8, 13), columnError(10, 13)), source)
   }
 
   @Test def testSingleLineNotAllowed(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  val foo0 = if (true) "yes" else "no"
-  val foo1 = if (true)
-                 "yes"
-                 else
-                 "no"
-  val foo2 = if (true) { "yes" } else { "no" }
-  val foo3 = if (true) {
-                 "yes"
-                 } else {
-                 "no"
-                 }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  val foo0 = if (true) "yes" else "no"
+      |  val foo1 = if (true)
+      |                 "yes"
+      |                 else
+      |                 "no"
+      |  val foo2 = if (true) { "yes" } else { "no" }
+      |  val foo3 = if (true) {
+      |                 "yes"
+      |                 } else {
+      |                 "no"
+      |                 }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(6, 13)), source, Map("singleLineAllowed" -> "false"))
   }
 
   @Test def testDoubleLine(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  val foo0 = if (true) "yes" else { "no" }
-  val foo1 = if (true) "yes"
-                 else "no"
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  val foo0 = if (true) "yes" else { "no" }
+      |  val foo1 = if (true) "yes"
+      |                 else "no"
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("doubleLineAllowed" -> "true"))
   }
 
   @Test def testElseIf(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  val foo0 = if (true) "yes" else if (true) "no" else "bar"
-  val foo1 = if (true) "yes"
-             else if (true) "no" else "bar"
-  val foo1 = if (true) {
-        "yes"
-      } else if (true) {
-        "no"
-      } else {
-        "bar"
-      }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  val foo0 = if (true) "yes" else if (true) "no" else "bar"
+      |  val foo1 = if (true) "yes"
+      |             else if (true) "no" else "bar"
+      |  val foo1 = if (true) {
+      |        "yes"
+      |      } else if (true) {
+      |        "no"
+      |      } else {
+      |        "bar"
+      |      }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 13)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/ImportsCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ImportsCheckerTest.scala
@@ -33,80 +33,89 @@ class IllegalImportsCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[IllegalImportsChecker]
 
   @Test def testNone(): Unit = {
-    val source = """
-package foobar
-
-import java.util._
-
-object Foobar {
-  val foo = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util._
+      |
+      |object Foobar {
+      |  val foo = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testDefault(): Unit = {
-    val source = """package foobar
-
-import java.util._
-import sun.com.foobar;
-import sun._
-
-object Foobar {
-}
-""".stripMargin;
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util._
+      |import sun.com.foobar
+      |import sun._
+      |
+      |object Foobar {
+      |}
+    """.stripMargin.trim
 
     assertErrors(List(columnError(4, 0), columnError(5, 0)), source)
   }
 
   @Test def testRenamingWildcard(): Unit = {
-    val source = """package foobar
-
-import java.util.{List => JList}
-import java.lang.{Object => JObject}
-import java.util.{List,Map}
-import java.util.{_}
-import java.util._
-
-object Foobar {
-}
-""".stripMargin;
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util.{List => JList}
+      |import java.lang.{Object => JObject}
+      |import java.util.{List,Map}
+      |import java.util.{_}
+      |import java.util._
+      |
+      |object Foobar {
+      |}
+    """.stripMargin.trim
 
     assertErrors(List(columnError(3, 0), columnError(5, 0), columnError(6, 0), columnError(7, 0)), source, Map("illegalImports" -> "java.util._"))
   }
 
   @Test def testRenamingSpecific(): Unit = {
-    val source = """package foobar
-
-import java.util.{List => JList}
-import java.lang.{Object => JObject}
-import java.util.{Iterator => JIterator, List => JList, Collection => JCollection}
-import java.util.{List, Map}
-import java.util.{_}
-import java.util._
-
-object Foobar {
-}
-""".stripMargin;
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util.{List => JList}
+      |import java.lang.{Object => JObject}
+      |import java.util.{Iterator => JIterator, List => JList, Collection => JCollection}
+      |import java.util.{List, Map}
+      |import java.util.{_}
+      |import java.util._
+      |
+      |object Foobar {
+      |}
+    """.stripMargin.trim
 
     assertErrors(List(columnError(3, 0), columnError(5, 0), columnError(6, 0)), source,
         Map("illegalImports" -> "java.util.List, java.util.Map"))
   }
 
   @Test def testWithExemptImports(): Unit = {
-    val source = """package foobar
-
-import java.util.{List => JList}
-import java.lang.{Object => JObject}
-import java.util.{Iterator => JIterator, List => JList, Collection => JCollection}
-import java.util.{List, Map}
-import java.util.{_}
-import java.util._
-
-object Foobar {
-}
-                 """.stripMargin;
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util.{List => JList}
+      |import java.lang.{Object => JObject}
+      |import java.util.{Iterator => JIterator, List => JList, Collection => JCollection}
+      |import java.util.{List, Map}
+      |import java.util.{_}
+      |import java.util._
+      |
+      |object Foobar {
+      |}
+    """.stripMargin.replaceAll("^\\s+", "")
 
     assertErrors(List(columnError(5, 0), columnError(6, 0), columnError(7, 0), columnError(8, 0)), source,
       Map("illegalImports" -> "java.util._", "exemptImports" -> "java.util.List"))
@@ -119,18 +128,19 @@ class UnderscoreImportCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[UnderscoreImportChecker]
 
   @Test def testNone(): Unit = {
-    val source = """
-package foobar
-
-import java.util.List
-import java.util._
-import java.util.{_}
-import java.util.{Foo => Bar, _}
-
-object Foobar {
-  import scala._
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util.List
+      |import java.util._
+      |import java.util.{_}
+      |import java.util.{Foo => Bar, _}
+      |
+      |object Foobar {
+      |  import scala._
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 0), columnError(6, 0), columnError(7, 0), columnError(10, 2)), source)
   }
@@ -141,38 +151,40 @@ class ImportGroupingCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[ImportGroupingChecker]
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-import java.util.List;
-import java.util._ // here is a comment
-import java.util._
-
-object Foobar {
-  import java.util.Map
-}
-
-import java.util.Collection
-
-object Barbar {
-  import java.util.HashMap
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |import java.util.List
+      |import java.util._ // here is a comment
+      |import java.util._
+      |
+      |object Foobar {
+      |  import java.util.Map
+      |}
+      |
+      |import java.util.Collection
+      |
+      |object Barbar {
+      |  import java.util.HashMap
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(9, 2), columnError(12, 0), columnError(15, 2)), source)
   }
 
 
   @Test def testNone(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-}
-
-object Barbar {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |}
+      |
+      |object Barbar {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
@@ -227,10 +239,11 @@ class ImportOrderCheckerTest extends AssertionsForJUnit with CheckerTest {
   }
 
   @Test def testSubPackage(): Unit = {
-    val source = """
+    val source =
+    """
       |import foobar.subpackage.Foo
       |import foobar.Bar
-      """.stripMargin;
+    """.stripMargin
 
     val expected = List(
       columnError(3, 0, errorKey = errorKey("wrongOrderInGroup"),
@@ -240,10 +253,11 @@ class ImportOrderCheckerTest extends AssertionsForJUnit with CheckerTest {
   }
 
   @Test def testInGroupOrdering(): Unit = {
-    val source = """
+    val source =
+    """
       |import java.nio.ByteBuffer
       |import java.nio.file.{Paths, Files}
-      """.stripMargin;
+    """.stripMargin
 
     val expected = List(
       columnError(3, 21, errorKey = errorKey("wrongOrderInSelector"),
@@ -253,7 +267,8 @@ class ImportOrderCheckerTest extends AssertionsForJUnit with CheckerTest {
   }
 
   @Test def testImportGrouping(): Unit = {
-    val source = """
+    val source =
+    """
       |package foobar
       |
       |import java.util.Map
@@ -275,7 +290,7 @@ class ImportOrderCheckerTest extends AssertionsForJUnit with CheckerTest {
       |
       |object Foobar {
       |}
-      """.stripMargin;
+    """.stripMargin
 
     val expected = List(
       columnError(5, 20, errorKey = errorKey("wrongOrderInSelector"), args = List("Cipher", "Mac")),

--- a/src/test/scala/org/scalastyle/scalariform/LowercasePatternMatchCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/LowercasePatternMatchCheckerTest.scala
@@ -33,39 +33,41 @@ class LowercasePatternMatchCheckerTest extends AssertionsForJUnit with CheckerTe
   val classUnderTest = classOf[LowercasePatternMatchChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class F1 {
-  val lc = "foobar"
-
-  def fn(a: Any) = a match {
-    case "barbar" => "barbar"
-    case s: Int => "int"
-    case List(x, y) => "list"
-    case `lc` => "lc"
-  }
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |class F1 {
+      |  val lc = "foobar"
+      |
+      |  def fn(a: Any) = a match {
+      |    case "barbar" => "barbar"
+      |    case s: Int => "int"
+      |    case List(x, y) => "list"
+      |    case `lc` => "lc"
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-class F1 {
-  val lc = "foobar"
-
-  def fn(a: Any) = a match {
-    case "barbar" => "barbar"
-    case s: Int => "int"
-    case List(x, y) => "list"
-    case lc => "lc"
-  }
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |class F1 {
+      |  val lc = "foobar"
+      |
+      |  def fn(a: Any) = a match {
+      |    case "barbar" => "barbar"
+      |    case s: Int => "int"
+      |    case List(x, y) => "list"
+      |    case lc => "lc"
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(11, 9)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/MagicNumberCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/MagicNumberCheckerTest.scala
@@ -33,111 +33,117 @@ class MagicNumberCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[MagicNumberChecker]
 
   @Test def testVal(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-
-  val foo0 = -2
-  val foo1 = -1
-  val foo2 = 0
-  val foo3 = 1
-  val foo4 = 2
-  val foo5 = 3
-  val foo6 = 4
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |
+      |  val foo0 = -2
+      |  val foo1 = -1
+      |  val foo2 = 0
+      |  val foo3 = 1
+      |  val foo4 = 2
+      |  val foo5 = 3
+      |  val foo6 = 4
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testVar(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var foo0 = -2
-  var foo1 = -1
-  var foo2 = 0
-  var foo3 = 1
-  var foo4 = 2
-  var foo5 = 3
-  var foo6 = 4
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var foo0 = -2
+      |  var foo1 = -1
+      |  var foo2 = 0
+      |  var foo3 = 1
+      |  var foo4 = 2
+      |  var foo5 = 3
+      |  var foo6 = 4
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(10, 13), columnError(11, 13)), source)
   }
 
   @Test def testVar2(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var foo6 = 4
-  var foo7 = +4
-  var foo8 = -4
-  var bar1 = fn(7, -5)
-  var bar2 = fn(1, -5)
-
-  def fn(i: Int, j: Int) = i + j
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var foo6 = 4
+      |  var foo7 = +4
+      |  var foo8 = -4
+      |  var bar1 = fn(7, -5)
+      |  var bar2 = fn(1, -5)
+      |
+      |  def fn(i: Int, j: Int) = i + j
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(6, 13), columnError(7, 13), columnError(8, 16), columnError(8, 19), columnError(9, 19)), source)
   }
 
   @Test def testValLong(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-
-  val foo0 = -2L
-  val foo1 = -1L
-  val foo2 = 0L
-  val foo3 = 1L
-  val foo4 = 2L
-  val foo5 = 3L
-  val foo6 = 4L
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |
+      |  val foo0 = -2L
+      |  val foo1 = -1L
+      |  val foo2 = 0L
+      |  val foo3 = 1L
+      |  val foo4 = 2L
+      |  val foo5 = 3L
+      |  val foo6 = 4L
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testVarLong(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var foo0 = -2L
-  var foo1 = -1L
-  var foo2 = 0L
-  var foo3 = 1L
-  var foo4 = 2L
-  var foo5 = 3L
-  var foo6 = 4L
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var foo0 = -2L
+      |  var foo1 = -1L
+      |  var foo2 = 0L
+      |  var foo3 = 1L
+      |  var foo4 = 2L
+      |  var foo5 = 3L
+      |  var foo6 = 4L
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(10, 13), columnError(11, 13)), source)
   }
 
   @Test def testVar2Long(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var foo6 = 4L
-  var foo7 = +4L
-  var foo8 = -4L
-  var bar1 = fn(7L, -5L)
-  var bar2 = fn(1L, -5L)
-
-  def fn(i: Int, j: Int) = i + j
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var foo6 = 4L
+      |  var foo7 = +4L
+      |  var foo8 = -4L
+      |  var bar1 = fn(7L, -5L)
+      |  var bar2 = fn(1L, -5L)
+      |
+      |  def fn(i: Int, j: Int) = i + j
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(6, 13), columnError(7, 13), columnError(8, 16), columnError(8, 20), columnError(9, 20)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/MethodLengthCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/MethodLengthCheckerTest.scala
@@ -33,37 +33,38 @@ class MethodLengthCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[MethodLengthChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class F1() {
-  def method1() = {
-    def foobar() = { 5 }
-    2
-    3
-    4
-    5
-    6
-    7
-  }
-  def method2() = {
-    1
-    2
-    3
-    4
-    5
-    6
-  }
-  def method3() = {
-    def foobar() = { 5 }
-    2
-    3
-    4
-    5
-    6
-  }
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |class F1() {
+      |  def method1() = {
+      |    def foobar() = { 5 }
+      |    2
+      |    3
+      |    4
+      |    5
+      |    6
+      |    7
+      |  }
+      |  def method2() = {
+      |    1
+      |    2
+      |    3
+      |    4
+      |    5
+      |    6
+      |  }
+      |  def method3() = {
+      |    def foobar() = { 5 }
+      |    2
+      |    3
+      |    4
+      |    5
+      |    6
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6, List("7"))), source, Map("maxLength" -> "7"))
   }

--- a/src/test/scala/org/scalastyle/scalariform/MultipleStringLiteralsCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/MultipleStringLiteralsCheckerTest.scala
@@ -33,74 +33,81 @@ class MultipleStringLiteralsCheckerTest extends AssertionsForJUnit with CheckerT
   val classUnderTest = classOf[MultipleStringLiteralsChecker]
 
   @Test def testParameters(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var a = "foobar"
-  var b = "foobar"
-  var c = "foobar"
-  val d = "foobar"
-  def e = "foobar"
-  def f(f: String = "foobar") = 5
-
-  var a1 = "bar"
-  val d1 = "bar"
-  def e1 = "bar"
-  def f1(f: String = "bar") = "foobar"
-
-  val a2 = "1"
-  val b2 = "1"
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var a = "foobar"
+      |  var b = "foobar"
+      |  var c = "foobar"
+      |  val d = "foobar"
+      |  def e = "foobar"
+      |  def f(f: String = "foobar") = 5
+      |
+      |  var a1 = "bar"
+      |  val d1 = "bar"
+      |  def e1 = "bar"
+      |  def f1(f: String = "bar") = "foobar"
+      |
+      |  val a2 = "1"
+      |  val b2 = "1"
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 10, List(""""foobar"""", "7", "3")), columnError(12, 11, List(""""bar"""", "4", "3"))), source,
                     Map("allowed" -> "3", "ignoreRegex" -> "1"))
   }
 
   @Test def testDefaultParameters(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var a = "foobar"
-  var b = "foobar"
-
-  var a1 = "bar"
-
-  var a2 = ""
-  var b2 = ""
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var a = "foobar"
+      |  var b = "foobar"
+      |
+      |  var a1 = "bar"
+      |
+      |  var a2 = ""
+      |  var b2 = ""
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 10, List(""""foobar"""", "2", "1"))), source)
   }
 
   @Test def testMultiLine(): Unit = {
-    val source = """
-package foobar
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var a = ###foobar
+      |  oop###
+      |  var b = ###foobar
+      |  oop###
+      |}
+    """.stripMargin.replace("###", "\"\"\"")
 
-class Foobar {
-  var a = ###foobar
-  oop###
-  var b = ###foobar
-  oop###
-}
-""".replace("###", "\"\"\"");
-
-    assertErrors(List(columnError(5, 10, List(""""foobar
-  oop"""", "2", "1"))), source)
+    assertErrors(List(columnError(5, 10, List(
+    """
+      |"foobar
+      |  oop"
+    """.stripMargin.trim, "2", "1"))), source)
   }
 
   @Test def testMultiLineAndNormal(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  var a = ###foobar###
-  var b = "foobar"
-}
-""".replace("###", "\"\"\"");
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  var a = ###foobar###
+      |  var b = "foobar"
+      |}
+    """.stripMargin.replace("###", "\"\"\"")
 
     assertErrors(List(columnError(5, 10, List(""""foobar"""", "2", "1"))), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/NoCloneCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NoCloneCheckerTest.scala
@@ -33,49 +33,53 @@ class NoCloneCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[NoCloneChecker]
 
   @Test def testClassOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def clone(o: java.lang.Integer): Any = null
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def clone(o: java.lang.Integer): Any = null
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testClassCovariantEqualsNoObjectKO(): Unit = {
-    val source = """
-package foobar
-
-class CloneKO {
-  def clone(): Any = null
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class CloneKO {
+      |  def clone(): Any = null
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testObjectOK(): Unit = {
-    val source = """
-package foobar
-
-object OK {
-  def clone(o: java.lang.Integer): Any = null
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object OK {
+      |  def clone(o: java.lang.Integer): Any = null
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testObjectCovariantEqualsNoObjectKO(): Unit = {
-    val source = """
-package foobar
-
-object CloneKO {
-  def clone(): Any = null
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object CloneKO {
+      |  def clone(): Any = null
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 7)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/NoFinalizeCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NoFinalizeCheckerTest.scala
@@ -33,49 +33,53 @@ class NoFinalizeCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[NoFinalizeChecker]
 
   @Test def testClassOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def finalize(o: java.lang.Integer): Unit = {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def finalize(o: java.lang.Integer): Unit = {}
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testClassCovariantEqualsNoObjectKO(): Unit = {
-    val source = """
-package foobar
-
-class CloneKO {
-  def finalize(): Unit = {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class CloneKO {
+      |  def finalize(): Unit = {}
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testObjectOK(): Unit = {
-    val source = """
-package foobar
-
-object OK {
-  def finalize(o: java.lang.Integer): Unit = {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object OK {
+      |  def finalize(o: java.lang.Integer): Unit = {}
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testObjectCovariantEqualsNoObjectKO(): Unit = {
-    val source = """
-package foobar
-
-object CloneKO {
-  def finalize(): Unit = {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object CloneKO {
+      |  def finalize(): Unit = {}
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 7)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/NoWhitespaceBracketCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NoWhitespaceBracketCheckerTest.scala
@@ -33,33 +33,36 @@ class NoWhitespaceBeforeLeftBracketCheckerTest extends AssertionsForJUnit with C
   val classUnderTest = classOf[NoWhitespaceBeforeLeftBracketChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class Foobar[T] {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar[T] {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOneSpace(): Unit = {
-    val source = """
-package foobar
-
-class Foobar [T] {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar [T] {
+      |}
+    """.stripMargin
     assertErrors(List(columnError(4, 6)), source)
   }
 
   @Test def testTwoSpaces(): Unit = {
-    val source = """
-package foobar
-
-class Foobar [ Barbar [T]] {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar [ Barbar [T]] {
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6), columnError(4, 15)), source)
   }
@@ -70,34 +73,37 @@ class NoWhitespaceAfterLeftBracketCheckerTest extends AssertionsForJUnit with Ch
   val classUnderTest = classOf[NoWhitespaceAfterLeftBracketChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class Foobar[T] {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar[T] {
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOneSpace(): Unit = {
-    val source = """
-package foobar
-
-class Foobar[ T] {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar[ T] {
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 12)), source)
   }
 
   @Test def testTwoSpaces(): Unit = {
-    val source = """
-package foobar
-
-class Foobar[ Barbar[ T]] {
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar[ Barbar[ T]] {
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 12), columnError(4, 20)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/NonASCIICharacterCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NonASCIICharacterCheckerTest.scala
@@ -28,27 +28,30 @@ class NonASCIICharacterCheckerTest extends AssertionsForJUnit with CheckerTest {
 
 
   @Test def testClassOK(): Unit = {
-    val source = """
-                   |package foobar
-                   |// ~~$%
-                   |class OK {
-                   |  def -> = "something"
-                   |  val `=>` = "test"
-                   |}""".stripMargin
+    val source =
+    """
+      |package foobar
+      |// ~~$%
+      |class OK {
+      |  def -> = "something"
+      |  val `=>` = "test"
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
 
   @Test def testClassNotOk(): Unit = {
-    val source = """
-                   |package foobar
-                   |// \u2190
-                   |class NotOK {
-                   |  def \u2192 = "something"
-                   |  def `\u21d2` = "test"
-                   |}
-                   | """.stripMargin
+    val source =
+    """
+      |package foobar
+      |// \u2190
+      |class NotOK {
+      |  def \u2192 = "something"
+      |  def `\u21d2` = "test"
+      |}
+    """.stripMargin
     assertErrors(List(columnError(2, 14), columnError(5, 6), columnError(6, 6)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/NotImplementedErrorUsageTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NotImplementedErrorUsageTest.scala
@@ -29,21 +29,25 @@ class NotImplementedErrorUsageTest extends AssertionsForJUnit with CheckerTest {
 
   @Test
   def noErrors(): Unit = {
-    val source = """
-class X {
-  val x = 0
-}
-      """
+    val source =
+    """
+      |class X {
+      |  val x = 0
+      |}
+    """.stripMargin
+
     assertErrors(Nil, source)
   }
 
   @Test
   def notImplementedErrorFound(): Unit = {
-    val source = """
-class X {
-  val x = ???
-}
-      """
+    val source =
+    """
+      |class X {
+      |  val x = ???
+      |}
+    """.stripMargin
+
     assertErrors(List(columnError(3, 10)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/NullCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NullCheckerTest.scala
@@ -33,26 +33,28 @@ class NullCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[NullChecker]
 
   @Test def testZero(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo: String = null
-  val bar: String = null
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo: String = null
+      |  val bar: String = null
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 20), columnError(6, 20)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/NumberOfMethodsInTypeCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NumberOfMethodsInTypeCheckerTest.scala
@@ -33,27 +33,28 @@ class NumberOfMethodsInTypeCheckerTest extends AssertionsForJUnit with CheckerTe
   val classUnderTest = classOf[NumberOfMethodsInTypeChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class F1() {
-  def method1() = 1
-  def method2() = 1
-  def method3() = 1
-  def method4() = 1
-  def method5() = 1
-}
-
-class F2() {
-  def method1() = {
-    def foobar() = 6
-    5
-  }
-  def method2() = 1
-  def method3() = 1
-  def method4() = 1
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class F1() {
+      |  def method1() = 1
+      |  def method2() = 1
+      |  def method3() = 1
+      |  def method4() = 1
+      |  def method5() = 1
+      |}
+      |
+      |class F2() {
+      |  def method1() = {
+      |    def foobar() = 6
+      |    5
+      |  }
+      |  def method2() = 1
+      |  def method3() = 1
+      |  def method4() = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(4, 6, List("4"))), source, Map("maxMethods" -> "4"))
   }

--- a/src/test/scala/org/scalastyle/scalariform/NumberOfTypesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NumberOfTypesCheckerTest.scala
@@ -33,49 +33,52 @@ class NumberOfTypesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[NumberOfTypesChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-case class F1()
-case class F2()
-case class F3()
-case class F4()
-case class F5()
-case class F6()
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |case class F1()
+      |case class F2()
+      |case class F3()
+      |case class F4()
+      |case class F5()
+      |case class F6()
+    """.stripMargin
 
     assertErrors(List(), source, Map("maxTypes" -> "6"))
   }
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-case class F1()
-case class F2()
-case class F3()
-case class F4()
-case class F5()
-case class F6()
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |case class F1()
+      |case class F2()
+      |case class F3()
+      |case class F4()
+      |case class F5()
+      |case class F6()
+    """.stripMargin
 
     assertErrors(List(fileError(List("5"))), source, Map("maxTypes" -> "5"))
   }
 
   @Test def testInnerClasses(): Unit = {
-    val source = """
-package foobar
-
-case class F1()
-case class F2()
-case class F3()
-case class F4()
-class F5() {
-  class Foobar {
-  }
-}
-case class F6()
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |case class F1()
+      |case class F2()
+      |case class F3()
+      |case class F4()
+      |class F5() {
+      |  class Foobar {
+      |  }
+      |}
+      |case class F6()
+    """.stripMargin
 
     assertErrors(List(fileError(List("6"))), source, Map("maxTypes" -> "6"))
   }

--- a/src/test/scala/org/scalastyle/scalariform/ParameterNumberCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ParameterNumberCheckerTest.scala
@@ -33,43 +33,46 @@ class ParameterNumberCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[ParameterNumberChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int): Int = 45
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int): Int = 45
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int, i9: Int): Int = 45
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int, i9: Int): Int = 45
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6, List("8"))), source)
   }
 
   @Test def testOuterKOInnerKO(): Unit = {
-    val source = """
-package foobar
-
-class Outer {
-  object Inner {
-    def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int, i9: Int): Int = 45
-  }
-
-  class Inner {
-    def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int, i9: Int): Int = 45
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Outer {
+      |  object Inner {
+      |    def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int, i9: Int): Int = 45
+      |  }
+      |
+      |  class Inner {
+      |    def method(i1: Int, i2: Int, i3: Int, i4: Int, i5: Int, i6: Int, i7: Int, i8: Int, i9: Int): Int = 45
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 8, List("8")), columnError(10, 8, List("8"))), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/PatternMatchAlignTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/PatternMatchAlignTest.scala
@@ -27,47 +27,53 @@ class PatternMatchAlignTest extends AssertionsForJUnit with CheckerTest {
   protected val key = "pattern.match.align"
 
   @Test def testNotAligned(): Unit = {
-    val source = """
-object foo {
-  val a = Some (4)
-
-  a match {
-    case Some(_) => "yes"
-    case _ => "no"
-  }
-}"""
+    val source =
+    """
+      |object foo {
+      |  val a = Some (4)
+      |
+      |  a match {
+      |    case Some(_) => "yes"
+      |    case _ => "no"
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(7, 11)), source)
   }
 
 
   @Test def testOk(): Unit = {
-    val source = """
-object foo {
-  val a = Some (4)
-
-  a match {
-    case Some(_) => "yes"
-    case _       => "no"
-  }
-}"""
+    val source =
+    """
+      |object foo {
+      |  val a = Some (4)
+      |
+      |  a match {
+      |    case Some(_) => "yes"
+      |    case _       => "no"
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testNested(): Unit = {
-    val source = """
-object foo {
-  val a = Some (4)
-
-  a match {
-    case Some(x) => x match {
-      case 3 => "no"
-      case 4  => "yrs"
-    }
-    case _       => "no"
-  }
-}"""
+    val source =
+    """
+      |object foo {
+      |  val a = Some (4)
+      |
+      |  a match {
+      |    case Some(x) => x match {
+      |      case 3 => "no"
+      |      case 4  => "yrs"
+      |    }
+      |    case _       => "no"
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(8, 14)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/ProcedureDeclarationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ProcedureDeclarationCheckerTest.scala
@@ -33,57 +33,61 @@ class ProcedureDeclarationCheckerTest extends AssertionsForJUnit with CheckerTes
   val classUnderTest = classOf[ProcedureDeclarationChecker]
 
   @Test def testClassOK(): Unit = {
-    val source = """
-package foobar
-
-abstract class OK {
-  def c1() = 5
-  def c2(): Int = 5
-  def c3 = 5
-  val foo2 = 2
-  def unit = {}
-  def unit2 {}
-  def unit3
-  def unit4: Unit
-  def unit5(i: Int) = {}
-  def unit6(i: Int) {}
-  def unit7(i: Int)
-  def unit8(i: Int): Unit
-  val foo: Unit = new scala.collection.mutable.HashMap {def foobar() = {}}
-  def bar() = { new scala.collection.mutable.HashMap {def foobar() = {}} }
-  def bar2() = new scala.collection.mutable.HashMap {def foobar2() = {}}
-  val bar3
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |abstract class OK {
+      |  def c1() = 5
+      |  def c2(): Int = 5
+      |  def c3 = 5
+      |  val foo2 = 2
+      |  def unit = {}
+      |  def unit2 {}
+      |  def unit3
+      |  def unit4: Unit
+      |  def unit5(i: Int) = {}
+      |  def unit6(i: Int) {}
+      |  def unit7(i: Int)
+      |  def unit8(i: Int): Unit
+      |  val foo: Unit = new scala.collection.mutable.HashMap {def foobar() = {}}
+      |  def bar() = { new scala.collection.mutable.HashMap {def foobar() = {}} }
+      |  def bar2() = new scala.collection.mutable.HashMap {def foobar2() = {}}
+      |  val bar3
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(10, 6), columnError(11, 6), columnError(14, 6), columnError(15, 6)), source)
   }
 
   @Test def testConstructor(): Unit = {
-    val source = """
-class ConstructorOK(a: Int) {
-  def this() = this(1)
-}
-"""
+    val source = 
+    """
+      |class ConstructorOK(a: Int) {
+      |  def this() = this(1)
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testConstructorWithBody(): Unit = {
-    val source = """
-package im.tox.tox4j
-
-final case class DhtNode(ipv4: String, ipv6: String, udpPort: Int, tcpPort: Int, dhtId: Array[Byte]) {
-
-  def this(ipv4: String, ipv6: String, udpPort: Int, tcpPort: Int, dhtId: String) {
-    this(ipv4, ipv6, udpPort, tcpPort, ToxCoreTestBase.parsePublicKey(dhtId))
-  }
-
-  def this(ipv4: String, ipv6: String, port: Int, dhtId: String) {
-    this(ipv4, ipv6, port, port, dhtId)
-  }
-
-}"""
+    val source = 
+    """
+      |package im.tox.tox4j
+      |
+      |final case class DhtNode(ipv4: String, ipv6: String, udpPort: Int, tcpPort: Int, dhtId: Array[Byte]) {
+      |
+      |  def this(ipv4: String, ipv6: String, udpPort: Int, tcpPort: Int, dhtId: String) {
+      |    this(ipv4, ipv6, udpPort, tcpPort, ToxCoreTestBase.parsePublicKey(dhtId))
+      |  }
+      |
+      |  def this(ipv4: String, ipv6: String, port: Int, dhtId: String) {
+      |    this(ipv4, ipv6, port, port, dhtId)
+      |  }
+      |
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/PublicMethodsHaveTypeCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/PublicMethodsHaveTypeCheckerTest.scala
@@ -33,75 +33,79 @@ class PublicMethodsHaveTypeCheckerTest extends AssertionsForJUnit with CheckerTe
   val classUnderTest = classOf[PublicMethodsHaveTypeChecker]
 
   @Test def testClassOK(): Unit = {
-    val source = """
-package foobar
-
-class OK {
-  def c1() = 5
-  def c2(): Int = 5
-  def c3 = 5
-  protected def c4() = 5
-  private def c5() = 5
-  private[this] def c6() = 5
-  private val foo1 = 1
-  val foo2 = 2
-  def unit = {}
-  def unit2 {}
-  val foo = new scala.collection.mutable.HashMap {def foobar1() = {}}
-  def bar() = { new scala.collection.mutable.HashMap {def foobar2() = {}} } // not picked up because inside a def
-  def bar2() = new scala.collection.mutable.HashMap {def foobar3() = {}} // not picked up because inside a def
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class OK {
+      |  def c1() = 5
+      |  def c2(): Int = 5
+      |  def c3 = 5
+      |  protected def c4() = 5
+      |  private def c5() = 5
+      |  private[this] def c6() = 5
+      |  private val foo1 = 1
+      |  val foo2 = 2
+      |  def unit = {}
+      |  def unit2 {}
+      |  val foo = new scala.collection.mutable.HashMap {def foobar1() = {}}
+      |  def bar() = { new scala.collection.mutable.HashMap {def foobar2() = {}} } // not picked up because inside a def
+      |  def bar2() = new scala.collection.mutable.HashMap {def foobar3() = {}} // not picked up because inside a def
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6), columnError(7, 6), columnError(13, 6),
                         columnError(16, 6), columnError(17, 6)), source)
   }
 
   @Test def testProc(): Unit = {
-    val source = """
-class classOK {
-  def proc1 {}
-  def proc2(): Unit = {}
-}
-
-abstract class abstractOK {
-  def proc1 {}
-  def proc2(): Unit = {}
-  def proc3()
-}
-
-trait traitOK {
-  def proc1 {}
-  def proc2(): Unit = {}
-  def proc3()
-}
-"""
+    val source =
+    """
+      |class classOK {
+      |  def proc1 {}
+      |  def proc2(): Unit = {}
+      |}
+      |
+      |abstract class abstractOK {
+      |  def proc1 {}
+      |  def proc2(): Unit = {}
+      |  def proc3()
+      |}
+      |
+      |trait traitOK {
+      |  def proc1 {}
+      |  def proc2(): Unit = {}
+      |  def proc3()
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testConstructor(): Unit = {
-    val source = """
-class ConstructorOK(a: Int) {
-  def this() = this(1)
-}
-"""
+    val source =
+    """
+      |class ConstructorOK(a: Int) {
+      |  def this() = this(1)
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testClassOverride(): Unit = {
-    val source = """
-package foobar
-
-trait Foobar {
-  def foobar: Int
-}
-
-class Sub extends Foobar {
-  override def foobar() = 5
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |trait Foobar {
+      |  def foobar: Int
+      |}
+      |
+      |class Sub extends Foobar {
+      |  override def foobar() = 5
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("ignoreOverride" -> "true"))
     assertErrors(List(columnError(9, 15)), source, Map("ignoreOverride" -> "false"))
@@ -109,48 +113,51 @@ class Sub extends Foobar {
   }
 
   @Test def testNestedDefInDef(): Unit = {
-    val source = """
-package foobar
-
-trait Foobar {
-  def foobar() = {
-    def nested1(): Int = 5
-    def nested2() = 5
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |trait Foobar {
+      |  def foobar() = {
+      |    def nested1(): Int = 5
+      |    def nested2() = 5
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 6)), source)
   }
 
   @Test def testNestedDefInVal(): Unit = {
-    val source = """
-package foobar
-
-trait Foobar {
-  val foobar = {
-    def nested1(): Int = 5
-    def nested2() = 5
-
-    nested2()
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |trait Foobar {
+      |  val foobar = {
+      |    def nested1(): Int = 5
+      |    def nested2() = 5
+      |
+      |    nested2()
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testNestedDefInVal2(): Unit = {
-    val source = """
-package foobar
-
-trait Foobar {
-  private val complexInit: Seq[Int] = {
-    def fancyStuff(x: Int) = x * 2
-    1.to(10).map(fancyStuff).toSeq
-  }
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |trait Foobar {
+      |  private val complexInit: Seq[Int] = {
+      |    def fancyStuff(x: Int) = x * 2
+      |    1.to(10).map(fancyStuff).toSeq
+      |  }
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/RedundantIfCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/RedundantIfCheckerTest.scala
@@ -27,39 +27,43 @@ class RedundantIfCheckerTest extends AssertionsForJUnit with CheckerTest {
   protected val key = "if.redundant"
 
   @Test def testErrors(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b1 = true
-  val b2 = if (b1) true else false
-  val b3 = if (!b1) false else true
-  val b4 =
-      if (b2 && b3)
-      true
-      else false
-  val b5 = if (b4) (if (b3) true else false) else b1
-  val b6 =
-      if (b1) true
-      else if (b2) true
-      else false
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b1 = true
+      |  val b2 = if (b1) true else false
+      |  val b3 = if (!b1) false else true
+      |  val b4 =
+      |      if (b2 && b3)
+      |      true
+      |      else false
+      |  val b5 = if (b4) (if (b3) true else false) else b1
+      |  val b6 =
+      |      if (b1) true
+      |      else if (b2) true
+      |      else false
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 11), columnError(7, 11), columnError(9, 6), columnError(12, 20), columnError(15, 11)), source)
   }
 
   @Test def testOk(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b1 = true
-  val b2 = false
-  val b3 =
-      if (b1) true
-      else if (!b1 && b2) false
-      else !b1
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b1 = true
+      |  val b2 = false
+      |  val b3 =
+      |      if (b1) true
+      |      else if (!b1 && b2) false
+      |      else !b1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/ReturnCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ReturnCheckerTest.scala
@@ -34,23 +34,26 @@ class ReturnCheckerTest extends AssertionsForJUnit with CheckerTest {
   protected val key = "return"
 
   @Test def testZeroErrors(): Unit = {
-    val source = """
-         |package foobar
-         |object Foobar {
-         |}
-         """.stripMargin
+    val source = 
+    """
+      |package foobar
+      |object Foobar {
+      |}
+    """.stripMargin
+
     assertErrors(List(), source)
   }
 
   @Test def testOneError(): Unit = {
     val source = """
-         |package foobar
-         |object Foobar {
-         |   def boo: String = {
-         |      return " return here"
-         |   }
-         |}
-         """.stripMargin
+      |package foobar
+      |object Foobar {
+      |   def boo: String = {
+      |      return " return here"
+      |   }
+      |}
+    """.stripMargin
+
     assertErrors(List(columnError(5, 6)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
@@ -61,20 +61,20 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
     val annotatedCaseClassSource = s"%scase class Foo @JpaAbomination() (@Field a: Int, @Field b: Int)"
     val annotatedCaseClassSource2 = s"""%scase class Foo @JpaAbomination(me) (@Field(a = 4, b = "foo") a: Int, @Field() b: Int)"""
     val missingParamDoc =
-      """
-        |/**
-        | * This is the documentation for whatever follows
-        | */
-      """.stripMargin
+    """
+      |/**
+      | * This is the documentation for whatever follows
+      | */
+    """.stripMargin
     val doc =
-      """
-        |/**
-        | * This is the documentation for whatever follows
-        | *
-        | * @param a the value of a
-        | * @param b the value of b
-        | */
-      """.stripMargin
+    """
+      |/**
+      | * This is the documentation for whatever follows
+      | *
+      | * @param a the value of a
+      | * @param b the value of b
+      | */
+    """.stripMargin
 
     List(classSource, caseClassSource, annotatedCaseClassSource, annotatedCaseClassSource2).foreach { source =>
       assertErrors(Nil, source format doc)
@@ -87,11 +87,11 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
     val specClassSource = "%sclass FooSpec"
     val specITClassSource = "%sclass FooSpecIT"
     val doc =
-      """
-        |/**
-        | * This is the documentation for whatever follows
-        | */
-      """.stripMargin
+    """
+      |/**
+      | * This is the documentation for whatever follows
+      | */
+    """.stripMargin
 
     List(specClassSource, specITClassSource).foreach { source =>
       assertErrors(List(lineError(1, List(Missing))), source format "")
@@ -106,20 +106,20 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
     val classSource = "%sclass Foo[A, B]"
     val caseClassSource = "%scase class Foo[A, B]()"
     val malformedDoc =
-      """
-        |/**
-        | * This is the documentation for whatever follows
-        | */
-      """.stripMargin
+    """
+      |/**
+      | * This is the documentation for whatever follows
+      | */
+    """.stripMargin
     val doc =
-      """
-        |/**
-        | * This is the documentation for whatever follows with tparams
-        | *
-        | * @tparam A the type A
-        | * @tparam B the type B
-        | */
-      """.stripMargin
+    """
+      |/**
+      | * This is the documentation for whatever follows with tparams
+      | *
+      | * @tparam A the type A
+      | * @tparam B the type B
+      | */
+    """.stripMargin
 
     List(traitSource, classSource, caseClassSource).foreach { source =>
       assertErrors(Nil, source format doc)
@@ -131,86 +131,86 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
   @Test def publicMethodWithEverything(): Unit = {
     def al(access: String = "", checked: Boolean): Unit = {
       val fun =
-        s"""
-          |/**
-          | * XXX
-          | */
-          |trait X {
-          |  %s${access} def foo[A, B, U](a: A, b: B): U = ???
-          |}
-        """.stripMargin
+      s"""
+        |/**
+        | * XXX
+        | */
+        |trait X {
+        |  %s${access} def foo[A, B, U](a: A, b: B): U = ???
+        |}
+      """.stripMargin
       val annotatedFun =
-        s"""
-          |/**
-          | * XXX
-          | */
-          |trait X {
-          |  %s${access} def foo[@unchecked A, @annotated B, U](@Field() a: A, @Field("b") b: B): U = ???
-          |}
-        """.stripMargin
+      s"""
+        |/**
+        | * XXX
+        | */
+        |trait X {
+        |  %s${access} def foo[@unchecked A, @annotated B, U](@Field() a: A, @Field("b") b: B): U = ???
+        |}
+      """.stripMargin
       val proc1 =
-        s"""
-          |/**
-          | * XXX
-          | */
-          |trait X {
-          |  %s${access} def foo[A, B, U](a: A, b: B): Unit = ()
-          |}
-        """.stripMargin
+      s"""
+        |/**
+        | * XXX
+        | */
+        |trait X {
+        |  %s${access} def foo[A, B, U](a: A, b: B): Unit = ()
+        |}
+      """.stripMargin
       val proc2 =
-        s"""
-          |/**
-          | * XXX
-          | */
-          |trait X {
-          |  %s${access} def foo[A, B, U](a: A, b: B) {}
-          |}
-        """.stripMargin
+      s"""
+        |/**
+        | * XXX
+        | */
+        |trait X {
+        |  %s${access} def foo[A, B, U](a: A, b: B) {}
+        |}
+      """.stripMargin
       def doc(proc: Boolean) =
-        """
-          |/**
-          | * Does foo
-          | * @param a the A
-          | * @param b the B
-          | * @tparam A the A
-          | * @tparam B the B
-          | * @tparam U the U%s
-          | */
-        """.stripMargin format (if (proc) "" else "\n * @return some u")
+      """
+        |/**
+        | * Does foo
+        | * @param a the A
+        | * @param b the B
+        | * @tparam A the A
+        | * @tparam B the B
+        | * @tparam U the U%s
+        | */
+      """.stripMargin format (if (proc) "" else "\n * @return some u")
 
       def missingTypeParamsDoc(proc: Boolean) =
-        """
-          |/**
-          | * Does foo
-          | * @param a the A
-          | * @param b the B
-          | * @tparam A the A
-          | * @tparam U the U%s
-          | */
-          | """.stripMargin format (if (proc) "" else "\n * @return some u")
+      """
+        |/**
+        | * Does foo
+        | * @param a the A
+        | * @param b the B
+        | * @tparam A the A
+        | * @tparam U the U%s
+        | */
+      """.stripMargin format (if (proc) "" else "\n * @return some u")
 
       def missingParamsDoc(proc: Boolean) =
-        """
-          |/**
-          | * Does foo
-          | * @param a the A
-          | * @tparam A the A
-          | * @tparam B the B
-          | * @tparam U the U%s
-          | */
-          | """.stripMargin format (if (proc) "" else "\n * @return some u")
+      """
+        |/**
+        | * Does foo
+        | * @param a the A
+        | * @tparam A the A
+        | * @tparam B the B
+        | * @tparam U the U%s
+        | */
+      """.stripMargin format (if (proc) "" else "\n * @return some u")
 
       val missingReturnDoc =
-        """
-          |/**
-          | * Does foo
-          | * @param a the A
-          | * @param b the b
-          | * @tparam A the A
-          | * @tparam B the B
-          | * @tparam U the U
-          | */
-          | """.stripMargin
+      """
+        |/**
+        | * Does foo
+        | * @param a the A
+        | * @param b the b
+        | * @tparam A the A
+        | * @tparam B the B
+        | * @tparam U the U
+        | */
+      """.stripMargin
 
       List(fun, annotatedFun).foreach { source =>
         assertErrors(Nil, source format doc(false))
@@ -247,30 +247,30 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
 
   @Test def returnAsParamDescription(): Unit = {
     val source =
-      """
-        |/**
-        | * Doc
-        | */
-        |object X {
-        |
-        |  /**
-        |   * Foo does some foos. With a
-        |   *
-        |   * ```
-        |   *     code example here
-        |   * ```
-        |   * and something or other else with ``code`` and (link)[to]
-        |   *
-        |   * @param a
-        |   *   Some text for parameter A
-        |   *   More for A
-        |   * @param b B
-        |   * @param c
-        |   * @return some integer
-        |   */
-        |  def foo(a: Int, b: Int, c: Int): Int = a + b
-        |}
-      """.stripMargin
+    """
+      |/**
+      | * Doc
+      | */
+      |object X {
+      |
+      |  /**
+      |   * Foo does some foos. With a
+      |   *
+      |   * ```
+      |   *     code example here
+      |   * ```
+      |   * and something or other else with ``code`` and (link)[to]
+      |   *
+      |   * @param a
+      |   *   Some text for parameter A
+      |   *   More for A
+      |   * @param b B
+      |   * @param c
+      |   * @return some integer
+      |   */
+      |  def foo(a: Int, b: Int, c: Int): Int = a + b
+      |}
+    """.stripMargin
 
     assertErrors(List(lineError(22, List(emptyParam("c")))), source)
   }
@@ -278,24 +278,24 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
   @Test def valsVarsAndTypes(): Unit = {
     def al(what: String = "", checked: Boolean): Unit = {
       val tlDoc =
-        """
-          |/**
-          | * Top-level doc
-          | */
-        """.stripMargin
+      """
+        |/**
+        | * Top-level doc
+        | */
+      """.stripMargin
       def source(container: String) =
-        s"""
-           |$tlDoc
-           |$container Foo {
-           |  %s${what}
-           |}
-        """.stripMargin
+      s"""
+         |$tlDoc
+         |$container Foo {
+         |  %s${what}
+         |}
+      """.stripMargin
       val doc =
-        """
-          |/**
-          | * This is the documentation for whatever follows with no params, no tparams, no return, no throws
-          | */
-        """.stripMargin
+      """
+        |/**
+        | * This is the documentation for whatever follows with no params, no tparams, no return, no throws
+        | */
+      """.stripMargin
 
       List(source("class"), source("case class"), source("object ")).foreach { source =>
         assertErrors(Nil, source format doc)
@@ -315,59 +315,62 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
 
   @Test def objectAfterPackage(): Unit = {
     val source =
-      """
-        |package org.example.test
-        |
-        |/**
-        | * Doc
-        | */
-        |object X {
-        |
-        |}
-      """.stripMargin
+    """
+      |package org.example.test
+      |
+      |/**
+      | * Doc
+      | */
+      |object X {
+      |
+      |}
+    """.stripMargin
 
     assertErrors(Nil, source)
   }
 
   @Test def severalObjects(): Unit = {
     val source =
-      """
-        |/**
-        | * Doc X
-        | */
-        |object X
-        |
-        |/**
-        | * Doc Y
-        | */
-        |object Y""".stripMargin
+    """
+      |/**
+      | * Doc X
+      | */
+      |object X
+      |
+      |/**
+      | * Doc Y
+      | */
+      |object Y
+    """.stripMargin
 
     assertErrors(Nil, source)
   }
 
   @Test def secondObjectMissingDoc(): Unit = {
     val source =
-      """
-        |/**
-        | * Doc X
-        | */
-        |object X
-        |
-        |object Y""".stripMargin
+    """
+      |/**
+      | * Doc X
+      | */
+      |object X
+      |
+      |object Y
+    """.stripMargin
 
     assertErrors(List(lineError(7, List(Missing))), source)
   }
 
   @Test def nestedObjectMissingDoc(): Unit = {
     val source =
-      """
-        |/**
-        | * Doc X
-        | */
-        |object X {
-        |
-        |  object Y
-        |}""".stripMargin
+    """
+      |/**
+      | * Doc X
+      | */
+      |object X {
+      |
+      |  object Y
+      |}
+    """.stripMargin
 
     assertErrors(List(lineError(7, List(Missing))), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/SimplifyBooleanExpressionCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SimplifyBooleanExpressionCheckerTest.scala
@@ -27,75 +27,85 @@ class SimplifyBooleanExpressionCheckerTest extends AssertionsForJUnit with Check
   protected val key = "simplify.boolean.expression"
 
   @Test def testEquals(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b = true
-  val foo01 = (b == true)
-  val foo02 = (b != true)
-  val foo03 = (b == false)
-  val foo04 = (b != false)
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b = true
+      |  val foo01 = (b == true)
+      |  val foo02 = (b != true)
+      |  val foo03 = (b == false)
+      |  val foo04 = (b != false)
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 15), columnError(7, 15), columnError(8, 15), columnError(9, 15)), source)
   }
 
 
   @Test def testErrors(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b = true
-  val foo01 = (b == true)
-  val foo02 = !false
-  val foo03 = !true
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b = true
+      |  val foo01 = (b == true)
+      |  val foo02 = !false
+      |  val foo03 = !true
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 15), columnError(7, 14), columnError(8, 14)), source)
   }
 
   @Test def testErrors2(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b = true
-  val foo04 = b && true
-  val foo05 = true && b
-  val foo06 = b && false
-  val foo07 = false && b
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b = true
+      |  val foo04 = b && true
+      |  val foo05 = true && b
+      |  val foo06 = b && false
+      |  val foo07 = false && b
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 14), columnError(7, 14), columnError(8, 14), columnError(9, 14)), source)
   }
 
   @Test def testErrors3(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b = true
-  val foo08 = b || true
-  val foo09 = true || b
-  val foo10 = b || false
-  val foo11 = false || b
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b = true
+      |  val foo08 = b || true
+      |  val foo09 = true || b
+      |  val foo10 = b || false
+      |  val foo11 = false || b
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 14), columnError(7, 14), columnError(8, 14), columnError(9, 14)), source)
   }
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val b = true
-  val foo12 = b && b // doesn't match
-  val foo13 = (b && b) || b
-  val foo14 = b && (true)
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val b = true
+      |  val foo12 = b && b // doesn't match
+      |  val foo13 = (b && b) || b
+      |  val foo14 = b && (true)
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(8, 14)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/SpaceAfterCommentStartCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SpaceAfterCommentStartCheckerTest.scala
@@ -28,92 +28,104 @@ class SpaceAfterCommentStartCheckerTest extends AssertionsForJUnit with CheckerT
   override protected val classUnderTest = classOf[SpaceAfterCommentStartChecker]
 
   @Test def testSinglelineComments(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  //Incorrect
-  // correct comment
-  /////////////////////////////////
-  ///Invalid
-  /// Invalid
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  //Incorrect
+      |  // correct comment
+      |  /////////////////////////////////
+      |  ///Invalid
+      |  /// Invalid
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 2), columnError(8, 2), columnError(9, 2)), source)
   }
 
   @Test def testMultipleInlineComments(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  //Incorrect
-  // correct comment//not wrong//check
-  val a = 10//Incorrect
-  val b = 100 //Incorrect
-  val c = 1// Correct
-  val d = 2 // Correct
-  val e = 3
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  //Incorrect
+      |  // correct comment//not wrong//check
+      |  val a = 10//Incorrect
+      |  val b = 100 //Incorrect
+      |  val c = 1// Correct
+      |  val d = 2 // Correct
+      |  val e = 3
+      |}
+    """.stripMargin
     assertErrors(List(columnError(5, 2), columnError(7, 12), columnError(8, 14)), source)
 
   }
 
   @Test def testMultilineComments(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  /*WRONG
-  *
-  */
-  /* Correct */
-  /* Wrong*/
-  val d = 2 /*Wrong*/
-  /*
-   *Correct
-   */
-  val e = 3/* Correct */
-}"""
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  /*WRONG
+      |  *
+      |  */
+      |  /* Correct */
+      |  /* Wrong*/
+      |  val d = 2 /*Wrong*/
+      |  /*
+      |   *Correct
+      |   */
+      |  val e = 3/* Correct */
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 2), columnError(9, 2), columnError(10, 12)), source)
   }
 
 
   @Test def testScaladocsComments(): Unit = {
-    val source = """
-package foobar
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  /**WRONG
+      |  *
+      |  */
+      |  /** Correct */
+      |  val d = 2 /**Wrong*/
+      |  /** Wrong*/
+      |  /**
+      |   *Correct
+      |   */
+      |  val e = 3/** Correct */
+      |}
+    """.stripMargin
 
-object Foobar {
-  /**WRONG
-  *
-  */
-  /** Correct */
-  val d = 2 /**Wrong*/
-  /** Wrong*/
-  /**
-   *Correct
-   */
-  val e = 3/** Correct */
-}"""
     assertErrors(List(columnError(5, 2), columnError(9, 12), columnError(10, 2)), source)
   }
 
   @Test def testMixedComments(): Unit = {
-    val source = """
-package foobar
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  /**WRONG
+      |  *
+      |  */
+      |  /** Correct */
+      |  val d = 2 /*Wrong*/ //Wrong
+      |  /**
+      |   *Correct
+      |   */
+      |  val e = 3/** Correct */ // Correct
+      |}
+    """.stripMargin
 
-object Foobar {
-  /**WRONG
-  *
-  */
-  /** Correct */
-  val d = 2 /*Wrong*/ //Wrong
-  /**
-   *Correct
-   */
-  val e = 3/** Correct */ // Correct
-}"""
     assertErrors(List(columnError(5, 2), columnError(9, 12), columnError(9, 22)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/SpacesAfterPlusCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SpacesAfterPlusCheckerTest.scala
@@ -33,27 +33,29 @@ class SpacesAfterPlusCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[SpacesAfterPlusChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 1 + 2
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 1 + 2
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testNoSpaces(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 1 +2
-}
-
-class Clazz[+T <: AstNode]() // ignore + within type specification
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 1 +2
+      |}
+      |
+      |class Clazz[+T <: AstNode]() // ignore + within type specification
+    """.stripMargin
 
     assertErrors(List(columnError(5, 14)), source)
   }
@@ -81,32 +83,34 @@ class Clazz[+T <: AstNode]() // ignore + within type specification
         |object FooBar {
         |  def +(): Unit = ()
         |}
-    """.stripMargin
+      """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testTwoSpaces(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 1 +  2
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 1 +  2
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testPlusAtEndOfLine(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val someText = "f012345678901234567890123456789" +
-  " some more text"
-}
-""";
+    val source = 
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val someText = "f012345678901234567890123456789" +
+      |  " some more text"
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/SpacesBeforePlusCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/SpacesBeforePlusCheckerTest.scala
@@ -33,39 +33,42 @@ class SpacesBeforePlusCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[SpacesBeforePlusChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 12 + 2
-}
-class Clazz[+T <: AstNode]() // ignore + within type specification
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 12 + 2
+      |}
+      |class Clazz[+T <: AstNode]() // ignore + within type specification
+    """.stripMargin
 
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 12+ 2
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 12+ 2
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 14)), source)
   }
 
   @Test def testPlusAtBeginningOfLine(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo = 12
-+ 2
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo = 12
+      |+ 2
+      |}
+    """.stripMargin
 
     assertErrors(List(), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/StructuralTypeCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/StructuralTypeCheckerTest.scala
@@ -33,14 +33,15 @@ class StructuralTypeCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[StructuralTypeChecker]
 
   @Test def testKO(): Unit = {
-    val source = """
-package foobar
-
-class Foobar {
-  def string[T <: String](t: T) = {}
-  def structuralType[T <: {def close(): Unit }](t: T) = {}
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |class Foobar {
+      |  def string[T <: String](t: T) = {}
+      |  def structuralType[T <: {def close(): Unit }](t: T) = {}
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(6, 26)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/TokenCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/TokenCheckerTest.scala
@@ -27,30 +27,36 @@ class TokenCheckerTest extends AssertionsForJUnit with CheckerTest {
   protected val key = "token"
 
   @Test def testErrors1(): Unit = {
-    val source = """
-object foo {
-  def bar(x: Any) = x.asInstanceOf[Int]
-}"""
+    val source =
+    """
+      |object foo {
+      |  def bar(x: Any) = x.asInstanceOf[Int]
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(3, 22)), source, Map("regex" -> "^[ai]sInstanceOf$"))
   }
 
   @Test def testErrors2(): Unit = {
-    val source = """
-import collection.mutable._
-object foo {
-  def bar(x: Any) = new ArrayList[Int]()
-}"""
+    val source =
+    """
+      |import collection.mutable._
+      |object foo {
+      |  def bar(x: Any) = new ArrayList[Int]()
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(2, 18), columnError(4, 24)), source, Map("regex" -> "^ArrayList|ArrayBuffer|mutable$"))
   }
 
   @Test def testOk(): Unit = {
-    val source = """
-object foo {
-  /** asInstanceOf[Int] is not used */
-  def bar(x: Any) = 1
-}"""
+    val source =
+    """
+      |object foo {
+      |  /** asInstanceOf[Int] is not used */
+      |  def bar(x: Any) = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(), source, Map("regex" -> "^[ai]sInstanceOf$"))
   }

--- a/src/test/scala/org/scalastyle/scalariform/UppercaseLCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/UppercaseLCheckerTest.scala
@@ -33,16 +33,17 @@ class UppercaseLCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[UppercaseLChecker]
 
   @Test def testOK(): Unit = {
-    val source = """
-package foobar
-
-object Foobar {
-  val foo1 = 3l
-  val foo2 = 3L
-  val foo3 = 3
-  val foo4 = 65 + 3l
-}
-""";
+    val source =
+    """
+      |package foobar
+      |
+      |object Foobar {
+      |  val foo1 = 3l
+      |  val foo2 = 3L
+      |  val foo3 = 3
+      |  val foo4 = 65 + 3l
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(5, 13), columnError(8, 18)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/VarFieldCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/VarFieldCheckerTest.scala
@@ -33,36 +33,37 @@ class VarFieldCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[VarFieldChecker]
 
   @Test def testOne(): Unit = {
-    val source = """
-class C1 {
-  var f1 = 1
-  val f2 = 1
-  var f3
-  def m1() = {
-    var v1 = 1
-    v1
-  }
-  def m2() = {
-    val v2 = 1
-    def m3() = {
-      var v3 = 1
-      v3
-    }
-    m3()
-  }
-  val f4 = { (a: Int) =>
-    var v4 = a
-    v4
-  }
-  def m5() = {
-    var v5, v6
-    1
-  }
-}
-object O1 {
-  var f5 = 1
-}
-""";
+    val source =
+    """
+      |class C1 {
+      |  var f1 = 1
+      |  val f2 = 1
+      |  var f3
+      |  def m1() = {
+      |    var v1 = 1
+      |    v1
+      |  }
+      |  def m2() = {
+      |    val v2 = 1
+      |    def m3() = {
+      |      var v3 = 1
+      |      v3
+      |    }
+      |    m3()
+      |  }
+      |  val f4 = { (a: Int) =>
+      |    var v4 = a
+      |    v4
+      |  }
+      |  def m5() = {
+      |    var v5, v6
+      |    1
+      |  }
+      |}
+      |object O1 {
+      |  var f5 = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(3, 2), columnError(5, 2), columnError(28, 2)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/VarLocalCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/VarLocalCheckerTest.scala
@@ -33,36 +33,37 @@ class VarLocalCheckerTest extends AssertionsForJUnit with CheckerTest {
   val classUnderTest = classOf[VarLocalChecker]
 
   @Test def testOne(): Unit = {
-    val source = """
-class C1 {
-  var f1 = 1
-  val f2 = 1
-  var f3
-  def m1() = {
-    var v1 = 1
-    v1
-  }
-  def m2() = {
-    val v2 = 1
-    def m3() = {
-      var v3 = 1
-      v3
-    }
-    m3()
-  }
-  val f4 = { (a: Int) =>
-    var v4 = a
-    v4
-  }
-  def m5() = {
-    var v5, v6
-    1
-  }
-}
-object O1 {
-  var f5 = 1
-}
-""";
+    val source =
+    """
+      |class C1 {
+      |  var f1 = 1
+      |  val f2 = 1
+      |  var f3
+      |  def m1() = {
+      |    var v1 = 1
+      |    v1
+      |  }
+      |  def m2() = {
+      |    val v2 = 1
+      |    def m3() = {
+      |      var v3 = 1
+      |      v3
+      |    }
+      |    m3()
+      |  }
+      |  val f4 = { (a: Int) =>
+      |    var v4 = a
+      |    v4
+      |  }
+      |  def m5() = {
+      |    var v5, v6
+      |    1
+      |  }
+      |}
+      |object O1 {
+      |  var f5 = 1
+      |}
+    """.stripMargin
 
     assertErrors(List(columnError(7, 4), columnError(13, 6), columnError(19, 4), columnError(23, 4)), source)
   }

--- a/src/test/scala/org/scalastyle/scalariform/WhileCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/WhileCheckerTest.scala
@@ -29,45 +29,48 @@ class WhileCheckerTest extends AssertionsForJUnit with CheckerTest {
   protected val key = "while"
 
   @Test def testZeroErrors(): Unit = {
-    val source = """
-class C1 {
-  def m1(n: Int) = n
-}
-""";
+    val source =
+    """
+      |class C1 {
+      |  def m1(n: Int) = n
+      |}
+    """.stripMargin
     assertErrors(List(), source)
   }
 
   @Test def testOneError(): Unit = {
-    val source = """
-class C1 {
-  def m1(n: Int) = {
-    var count = 0
-    while (count < n) {
-      count += 1
-    }
-    count
-  }
-}
-"""
+    val source =
+    """
+      |class C1 {
+      |  def m1(n: Int) = {
+      |    var count = 0
+      |    while (count < n) {
+      |      count += 1
+      |    }
+      |    count
+      |  }
+      |}
+    """.stripMargin
     assertErrors(List(columnError(5, 4)), source)
   }
 
   @Test def testTwoErrors(): Unit = {
-    val source = """
-class C1 {
-  def m1(n: Int) = {
-    var count = 0
-    while (count < n) {
-      var count2 = count
-      while (count2 < n) {
-        count2 += 1
-      }
-      count += 1
-    }
-    count
-  }
-}
-"""
+    val source =
+    """
+      |class C1 {
+      |  def m1(n: Int) = {
+      |    var count = 0
+      |    while (count < n) {
+      |      var count2 = count
+      |      while (count2 < n) {
+      |        count2 += 1
+      |      }
+      |      count += 1
+      |    }
+      |    count
+      |  }
+      |}
+    """.stripMargin
     assertErrors(List(columnError(5, 4), columnError(7, 6)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/XmlLiteralCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/XmlLiteralCheckerTest.scala
@@ -29,41 +29,45 @@ class XmlLiteralCheckerTest extends AssertionsForJUnit with CheckerTest {
   protected val key = "xml.literal"
 
   @Test def testZeroErrors(): Unit = {
-    val source = """
-class C1 {
-  def m1(n: Int) = n
-}
-""";
+    val source =
+    """
+      |class C1 {
+      |  def m1(n: Int) = n
+      |}
+    """.stripMargin
     assertErrors(List(), source)
   }
 
   @Test def testOneError(): Unit = {
-    val source = """
-class C1 {
-  val f = <foobar/>
-}
-"""
+    val source =
+    """
+      |class C1 {
+      |  val f = <foobar/>
+      |}
+    """.stripMargin
     assertErrors(List(columnError(3, 10)), source)
   }
 
   @Test def testTwoErrors(): Unit = {
-    val source = """
-class C1 {
-  val f1 = <foobar/>
-  val f2 = <foobar/>
-}
-"""
+    val source =
+    """
+      |class C1 {
+      |  val f1 = <foobar/>
+      |  val f2 = <foobar/>
+      |}
+    """.stripMargin
     assertErrors(List(columnError(3, 11), columnError(4, 11)), source)
   }
 
   @Test def testMultiLine(): Unit = {
-    val source = """
-class C1 {
-  val f = <foobar>
-            <foo>&gt;</foo>
-          </foobar>
-}
-"""
+    val source =
+    """
+      |class C1 {
+      |  val f = <foobar>
+      |            <foo>&gt;</foo>
+      |          </foobar>
+      |}
+    """.stripMargin
     assertErrors(List(columnError(3, 10)), source)
   }
 }


### PR DESCRIPTION
This code uses stripMargin to with triple-quotes to make the code more readable. Also tries to make its usage consistent. Also removes semi-colons where not needed. I tried to make only there specific changes and no other. Let me know if the code deviates from this and I will revert those changes. No new tests need to be added but all the tests pass.
