### PR TITLE
Add option to warn if classes, methods, objects, and packages match a…

### DIFF
--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -29,6 +29,7 @@ import scala.collection.JavaConversions.collectionAsScalaIterable
 import scala.collection.JavaConversions.seqAsJavaList
 import scala.io.Codec
 import scala.io.Source
+import scala.util.matching.Regex
 
 case class Line(text: String, start: Int, end: Int)
 
@@ -243,6 +244,15 @@ trait Checker[A] {
 
   protected def isObject(s: String) = (s == "java.lang.Object" || s == "Any")
   protected def isNotObject(s: String) = !isObject(s)
+
+  protected def matchesBasedOnCondition(regex: Regex, text: String, matchCondition: Boolean) = {
+    if (matchCondition) {
+      regex.findAllIn(text).isEmpty
+    }
+    else {
+      regex.findAllIn(text).nonEmpty
+    }
+  }
 }
 
 trait FileChecker extends Checker[Lines]

--- a/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
@@ -35,15 +35,17 @@ import scala.util.matching.Regex
 
 class ClassNamesChecker extends ScalariformChecker {
   val DefaultRegex = "^[A-Z][A-Za-z]*$"
+  val DefaultMatchCondition = true
   val errorKey = "class.name"
 
   def verify(ast: CompilationUnit): List[ScalastyleError] = {
     val regexString = getString("regex", DefaultRegex)
     val regex = regexString.r
+    val matchCondition = getBoolean("match", DefaultMatchCondition)
 
     val it = for {
       List(left, right) <- ast.tokens.sliding(2)
-      if left.tokenType == CLASS && regex.findAllIn(right.text).isEmpty
+      if left.tokenType == CLASS && matchesBasedOnCondition(regex, right.text, matchCondition)
     } yield {
       PositionError(right.offset, List(regexString))
     }
@@ -54,15 +56,18 @@ class ClassNamesChecker extends ScalariformChecker {
 
 class ObjectNamesChecker extends ScalariformChecker {
   val DefaultRegex = "^[A-Z][A-Za-z]*$"
+  val DefaultMatchCondition = true
   val errorKey = "object.name"
 
   def verify(ast: CompilationUnit): List[PositionError] = {
     val regexString = getString("regex", DefaultRegex)
     val regex = regexString.r
+    val matchCondition = getBoolean("match", DefaultMatchCondition)
 
     val it = for {
       List(left, middle, right) <- ast.tokens.sliding(3)
-      if left.tokenType != PACKAGE && middle.tokenType == OBJECT && regex.findAllIn(right.text).isEmpty
+      if left.tokenType != PACKAGE && middle.tokenType == OBJECT &&
+        matchesBasedOnCondition(regex, right.text, matchCondition)
     } yield {
       PositionError(right.offset, List(regexString))
     }
@@ -73,11 +78,13 @@ class ObjectNamesChecker extends ScalariformChecker {
 
 class PackageNamesChecker extends ScalariformChecker {
   val DefaultRegex = "^[a-z][A-Za-z]*$"
+  val DefaultMatchCondition = true
   val errorKey = "package.name"
 
   def verify(ast: CompilationUnit): List[PositionError] = {
     val regexString = getString("regex", DefaultRegex)
     val regex = regexString.r
+    val matchCondition = getBoolean("match", DefaultMatchCondition)
 
     def isPartOfPackageName(t: Token): Boolean = (t.tokenType == DOT) || (t.tokenType == VARID)
 
@@ -102,7 +109,7 @@ class PackageNamesChecker extends ScalariformChecker {
 
     val it = for {
       pkgName <- packageNames.flatten
-      if regex.findAllIn(pkgName.text).isEmpty
+      if matchesBasedOnCondition(regex, pkgName.text, matchCondition)
     } yield {
       PositionError(pkgName.offset, List(regexString))
     }
@@ -113,15 +120,18 @@ class PackageNamesChecker extends ScalariformChecker {
 
 class PackageObjectNamesChecker extends ScalariformChecker {
   val DefaultRegex = "^[a-z][A-Za-z]*$"
+  val DefaultMatchCondition = true
   val errorKey = "package.object.name"
 
   def verify(ast: CompilationUnit): List[PositionError] = {
     val regexString = getString("regex", DefaultRegex)
     val regex = regexString.r
+    val matchCondition = getBoolean("match", DefaultMatchCondition)
 
     val it = for {
       List(left, middle, right) <- ast.tokens.sliding(3)
-      if left.tokenType == PACKAGE && middle.tokenType == OBJECT && regex.findAllIn(right.text).isEmpty
+      if left.tokenType == PACKAGE && middle.tokenType == OBJECT &&
+        matchesBasedOnCondition(regex, right.text, matchCondition)
     } yield {
       PositionError(right.offset, List(regexString))
     }
@@ -130,7 +140,8 @@ class PackageObjectNamesChecker extends ScalariformChecker {
   }
 }
 
-case class MethodNamesCheckerParameters(regexString: String, ignoreRegexString: String, ignoreOverride: Boolean) {
+case class MethodNamesCheckerParameters(regexString: String, ignoreRegexString: String, ignoreOverride: Boolean,
+                                        matchCondition: Boolean) {
   private val regexR = regexString.r
   private val ignoreRegexR = ignoreRegexString.r
 
@@ -142,11 +153,12 @@ class MethodNamesChecker extends AbstractSingleMethodChecker[MethodNamesCheckerP
   private val DefaultRegex = "^[a-z][A-Za-z0-9]*(_=)?$"
   private val DefaultIgnoreRegex = "^$"
   private val DefaultIgnoreOverride = false
+  private val DefaultMatchCondition = true
   val errorKey = "method.name"
 
   protected def matchParameters() = {
     MethodNamesCheckerParameters(getString("regex", DefaultRegex), getString("ignoreRegex", DefaultIgnoreRegex),
-        getBoolean("ignoreOverride", DefaultIgnoreOverride))
+        getBoolean("ignoreOverride", DefaultIgnoreOverride), getBoolean("match", DefaultMatchCondition))
   }
 
   protected def matches(t: FullDefOrDclVisit, p: MethodNamesCheckerParameters) = {
@@ -154,26 +166,29 @@ class MethodNamesChecker extends AbstractSingleMethodChecker[MethodNamesCheckerP
       false
     } else {
       val name = t.funDefOrDcl.nameToken.text
-      !matches(p.regex(), name) && !matches(p.ignoreRegex(), name)
+      !matches(p.regex(), name, p.matchCondition) && !matches(p.ignoreRegex(), name, p.matchCondition)
     }
   }
 
   protected override def describeParameters(p: MethodNamesCheckerParameters) = List("" + p.regex)
 
-  private def matches(regex: Regex, s: String) = regex.findFirstIn(s).isDefined
+  private def matches(regex: Regex, s: String, matchCondition: Boolean) =
+    regex.findFirstIn(s).isDefined && matchCondition
 }
 
 class FieldNamesChecker extends ScalariformChecker {
   val DefaultRegex = "^[a-z][A-Za-z0-9]*$"
   val errorKey = "field.name"
+  val DefaultMatchCondition = true
 
   def verify(ast: CompilationUnit): List[ScalastyleError] = {
     val regexString = getString("regex", DefaultRegex)
     val regex = regexString.r
+    val matchCondition = getBoolean("match", DefaultMatchCondition)
 
     val it = for {
       List(left, right) <- ast.tokens.sliding(2)
-      if (left.tokenType == VAL || left.tokenType == VAR) && regex.findAllIn(right.text).isEmpty
+      if (left.tokenType == VAL || left.tokenType == VAR) && matchesBasedOnCondition(regex, right.text, matchCondition)
     } yield {
       PositionError(right.offset, List(regexString))
     }

--- a/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
@@ -50,6 +50,18 @@ class foobar {
 
     assertErrors(List(columnError(4, 6, List("^[A-Z][A-Za-z]*$")), columnError(5, 8, List("^[A-Z][A-Za-z]*$"))), source)
   }
+
+  @Test def testNotMatch(): Unit = {
+    val source = """
+package foobar
+
+class FooUtil {
+  val one = 1
+}
+"""
+
+    assertErrors(List(columnError(4, 6, List("^*Util*$"))), source, Map("match" -> "false", "regex" -> "^*Util*$"))
+  }
 }
 
 class ObjectNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
@@ -92,6 +104,18 @@ package object foobar {
 """
 
     assertErrors(List(columnError(5, 9, List("^[A-Z][A-Za-z]*$"))), source)
+  }
+
+  @Test def testNotMatch(): Unit = {
+    val source = """
+package foobar
+
+object FooUtil {
+  val foo = 1
+}
+"""
+
+    assertErrors(List(columnError(4, 7, List("^*Util*$"))), source, Map("match" -> "false", "regex" -> "^*Util*$"))
   }
 }
 
@@ -178,6 +202,13 @@ package object _foo
     assertErrors(List(), source)
   }
 
+  @Test def testNotMatch(): Unit = {
+    val source = """
+package foobar
+"""
+
+    assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$"))), source, Map("match" -> "false"))
+  }
 }
 
 class PackageObjectNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
@@ -221,6 +252,18 @@ object foobar {
 
     assertErrors(List(), source)
   }
+
+  @Test def testNotMatch(): Unit = {
+    val source = """
+package foobar
+
+package object foobar {
+  val foo = 1
+}
+"""
+
+    assertErrors(List(columnError(4, 15, List("^[a-z][A-Za-z]*$"))), source, Map("match" -> "false"))
+  }
 }
 
 class MethodNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
@@ -240,6 +283,18 @@ class Foobar {
 """
 
     assertErrors(List(defErr(6, 6)), source)
+  }
+
+  @Test def testNoErrors(): Unit = {
+    val source = """
+package foobar
+
+class Foobar {
+  def foo() = 1
+}
+"""
+
+    assertErrors(List(), source)
   }
 
   @Test def testNonDefault(): Unit = {
@@ -292,6 +347,18 @@ class Foobar extends Bar {
     assertErrors(List(defErr(5, 6), defErr(6, 6), defErr(7, 6)), source, Map("ignoreOverride" -> "true"))
   }
 
+  @Test def testNotMatch(): Unit = {
+    val source = """
+package foobar
+
+class Foobar {
+  def foo() = 1
+}
+"""
+
+    assertErrors(List(defErr(5, 6)), source, Map("match" -> "false"))
+  }
+
   private def defErr(line: Int, column: Int) = columnError(line, column, List("^[a-z][A-Za-z0-9]*(_=)?$"))
 }
 
@@ -341,5 +408,18 @@ class FieldNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
         columnError(9, 21, List("^[a-z][A-Za-z0-9]*$")),
         columnError(10, 21, List("^[a-z][A-Za-z0-9]*$"))),
       source)
+  }
+
+  @Test def testNotMatch(): Unit = {
+    val source =
+      """
+        |package foobar
+        |
+        |class foobar {
+        |  val myField1 = "one"
+        |}
+      """.stripMargin
+
+    assertErrors(List(columnError(5, 6, List("^[a-z][A-Za-z0-9]*$"))), source, Map("match" -> "false"))
   }
 }


### PR DESCRIPTION
This way, a certain field can be rejected, e.g.
```xml
 <check class="org.scalastyle.scalariform.ClassNamesChecker" level="warning" enabled="true">
  <parameters>
   <parameter name="regex"><![CDATA[^*Util*$]]></parameter>
<parameter name="match">false</parameter>
  </parameters>
 </check>
```
will reject classes that have Util in them.

Added tests as well.