### PR TITLE
Add checker for unneeded string interpolation.

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -143,6 +143,7 @@
  </check>
  <check class="org.scalastyle.scalariform.UnderscoreImportChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.LowercasePatternMatchChecker" level="warning" enabled="true"></check>
+ <check class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" level="warning" enabled="true">
   <parameters>
    <parameter name="allowed"><![CDATA[2]]></parameter>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -342,3 +342,7 @@ todo.comment.label = "TODO/FIXME comment"
 todo.comment.description = "Check for use of TODO/FIXME single line comments"
 todo.comment.words.label = "Word list"
 todo.comment.words.description = "Alternative list of words to look for, separated by |"
+
+empty.interpolated.strings.message = "Unnecessary use of interpolated string"
+empty.interpolated.strings.label = "Empty interpolated string"
+empty.interpolated.strings.description = "The interpolation for this string literal is not nessescary"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -179,4 +179,5 @@
             <parameter name="words" type="string" default="TODO|FIXME" />
         </parameters>
     </checker>
+    <checker class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" id="empty.interpolated.strings" defaultLevel="warning"/>
 </scalastyle-definition>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -942,4 +942,15 @@ To bring consistency with how comments should be formatted, leave a space right 
   ]]>
   </example-configuration>
  </check>
+
+ <check id="empty.interpolated.strings">
+  <justification>
+   Empty interpolated strings are harder to read and not nessescary.
+  </justification>
+  <example-configuration>
+   <![CDATA[
+    <check class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" level="warning" enabled="true"/>
+   ]]>
+  </example-configuration>
+ </check>
 </scalastyle-documentation>

--- a/src/main/scala/org/scalastyle/scalariform/EmptyInterpolatedStringChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/EmptyInterpolatedStringChecker.scala
@@ -1,0 +1,38 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.scalastyle.{PositionError, ScalariformChecker, ScalastyleError}
+
+import _root_.scalariform.lexer.Tokens.INTERPOLATION_ID
+import _root_.scalariform.parser.CompilationUnit
+
+class EmptyInterpolatedStringChecker extends ScalariformChecker {
+  val errorKey = "empty.interpolated.strings"
+  val InterpolationRegex = """.*\$""".r
+
+  def verify(ast: CompilationUnit): List[ScalastyleError] = {
+    val it = for {
+        List(left, right) <- ast.tokens.sliding(2)
+        if left.tokenType == INTERPOLATION_ID && InterpolationRegex.findFirstIn(right.text).isEmpty
+      } yield {
+        PositionError(right.offset)
+      }
+
+    it.toList
+  }
+}

--- a/src/test/scala/org/scalastyle/scalariform/EmptyInterpolatedStringCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/EmptyInterpolatedStringCheckerTest.scala
@@ -14,77 +14,76 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.scalastyle.file
+package org.scalastyle.scalariform
 
 import org.junit.Test
+import org.scalastyle.file.CheckerTest
 import org.scalatest.junit.AssertionsForJUnit
 
 // scalastyle:off magic.number multiple.string.literals
 
-class WhitespaceEndOfLineCheckerTest extends AssertionsForJUnit with CheckerTest {
-  val key = "whitespace.end.of.line"
-  val classUnderTest = classOf[WhitespaceEndOfLineChecker]
+class EmptyInterpolatedStringCheckerTest extends AssertionsForJUnit with CheckerTest {
+  val key = "empty.interpolated.strings"
+  val classUnderTest = classOf[EmptyInterpolatedStringChecker]
 
   @Test def testZero(): Unit = {
     val source = """
 package foobar
 
-object Foobar {
+class Foobar {
+  val foo = "foo"
 }
 """
+    assertErrors(List(), source)
+  }
 
+  @Test def testCorrect(): Unit = {
+    val source = """
+package foobar
+
+class Foobar {
+  val foo = "foo"
+  val bar = s"$foo bar"
+}
+"""
     assertErrors(List(), source)
   }
 
   @Test def testOne(): Unit = {
     val source = """
-package foobar##
+package foobar
 
-object Foobar {
+class Foobar {
+  val foo = s"foo"
 }
-""".replaceAll("#", " ")
-
-    assertErrors(List(columnError(2, 14)), source)
+"""
+    assertErrors(List(columnError(5, 13)), source)
   }
 
-  @Test def testTwo(): Unit = {
-    val source = """
-package foobar~
-class  foobar#
-object Foobar {
-}
-""".replaceAll("~", " ").replaceAll("#", "\t")
-
-    assertErrors(List(columnError(2, 14), columnError(3, 13)), source)
-  }
-
-  @Test def testThree(): Unit = {
+  @Test def testMultiple(): Unit = {
     val source = """
 package foobar
 
-  object Foobar {
-    val foo = "foo"
-~~
-    val bar = "bar"
-##
-  }
-""".replaceAll("~", " ").replaceAll("#", "\t")
-
-    assertErrors(List(), source, Map("ignoreWhitespaceLines" -> "true"))
+class Foobar {
+  val foo = s"foo"
+  val bar = s""
+  val baz = s"   baz     "
+}
+"""
+    assertErrors(List(columnError(5, 13), columnError(6, 13), columnError(7, 13)), source)
   }
 
-  @Test def testFour(): Unit = {
+  @Test def testMix(): Unit = {
     val source = """
 package foobar
 
-  object Foobar {
-    val foo = "foo"
-~~
-    val bar = "bar"
-##
-  }
-""".replaceAll("~", " ").replaceAll("#", "\t")
-
-    assertErrors(List(columnError(6, 0), columnError(8, 0)), source, Map("ignoreWhitespaceLines" -> "false"))
+class Foobar {
+  val foo = s"foo"
+  val bar = s""
+  val real = s"this is $foo real $bar"
+  val baz = s"   baz     "
+}
+"""
+    assertErrors(List(columnError(5, 13), columnError(6, 13), columnError(8, 13)), source)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
@@ -58,8 +58,8 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
   @Test def classParams(): Unit = {
     val classSource = "%sclass Foo(a: Int, b: Int)"
     val caseClassSource = "%scase class Foo(a: Int, b: Int)"
-    val annotatedCaseClassSource = s"%scase class Foo @JpaAbomination() (@Field a: Int, @Field b: Int)"
-    val annotatedCaseClassSource2 = s"""%scase class Foo @JpaAbomination(me) (@Field(a = 4, b = "foo") a: Int, @Field() b: Int)"""
+    val annotatedCaseClassSource = "%scase class Foo @JpaAbomination() (@Field a: Int, @Field b: Int)"
+    val annotatedCaseClassSource2 = """%scase class Foo @JpaAbomination(me) (@Field(a = 4, b = "foo") a: Int, @Field() b: Int)"""
     val missingParamDoc =
       """
         |/**


### PR DESCRIPTION
Also fix two tests where this occurred (thanks to the checker). Add test and update reference.conf and documentation XML file. I also added this check to lib/scalastyle_config as I thought it may be useful to check for this in the code.
