### PR TITLE
Scalastyle for Scalastyle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,3 +98,9 @@ val dynamicPublish = Def.taskDyn {
 }
 
 ReleaseKeys.publishArtifactsAction := dynamicPublish.value
+
+lazy val testScalastyle = taskKey[Unit]("testScalastyle")
+
+testScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Compile).toTask("").value
+
+(test in Test) <<= (test in Test) dependsOn testScalastyle

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,116 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+  <parameters>
+   <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+   <parameter name="tabSize"><![CDATA[4]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="maxParameters"><![CDATA[8]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+  <parameters>
+   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+</scalastyle>

--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -38,17 +38,10 @@ case class LineColumn(line: Int, column: Int)
 
 case class Lines(lines: Array[Line], lastChar: Char) {
 
-  def findLineAndIndex(position:Int): Option[(Line, Int)] = {
-    var i = 0
-
-    lines.foreach(l => {
-      i = i + 1
-      if (position >= l.start && position < l.end) {
-        return Some((l, i))
-      }
-    })
-
-    None
+  def findLineAndIndex(position: Int): Option[(Line, Int)] = {
+    lines.zipWithIndex.find {
+      case (line, _) => position >= line.start && position < line.end
+    }.map(x => x.copy(_2 = x._2 + 1))
   }
 
   def toLineColumn(position: Int): Option[LineColumn] =
@@ -226,10 +219,12 @@ trait Checker[A] {
     val sErrorKey = customErrorKey.getOrElse(errorKey)
 
     p2 match {
-      case PositionError(position, args, errorKey) => StyleError(file, this.getClass(), errorKey.getOrElse(sErrorKey), level, args, customMessage = customMessage)
+      case PositionError(position, args, errorKey) =>
+        StyleError(file, this.getClass(), errorKey.getOrElse(sErrorKey), level, args, customMessage = customMessage)
       case FileError(args, errorKey) => StyleError(file, this.getClass(), errorKey.getOrElse(sErrorKey), level, args, None, None, customMessage)
       case LineError(line, args, errorKey) => StyleError(file, this.getClass(), errorKey.getOrElse(sErrorKey), level, args, Some(line), None, customMessage)
-      case ColumnError(line, column, args, errorKey) => StyleError(file, this.getClass(), errorKey.getOrElse(sErrorKey), level, args, Some(line), Some(column), customMessage)
+      case ColumnError(line, column, args, errorKey) =>
+        StyleError(file, this.getClass(), errorKey.getOrElse(sErrorKey), level, args, Some(line), Some(column), customMessage)
     }
   }
 

--- a/src/main/scala/org/scalastyle/file/WhitespaceEndOfLineChecker.scala
+++ b/src/main/scala/org/scalastyle/file/WhitespaceEndOfLineChecker.scala
@@ -42,10 +42,7 @@ class WhitespaceEndOfLineChecker extends FileChecker {
         whitespaces.contains(c)
       }.headOption.map{ case (c: Char, idx: Int) =>
         (true, s.length() - idx)
-      }.getOrElse {
-        if (ignoreWhitespaceLines) (false, 0)
-        else (true, 0)
-      }
+      }.getOrElse( (!ignoreWhitespaceLines, 0) )
     } ).getOrElse( (false, 0) )
   }
 

--- a/src/main/scala/org/scalastyle/scalariform/IfBraceChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/IfBraceChecker.scala
@@ -69,18 +69,20 @@ class IfBraceChecker extends CombinedChecker {
       case None => (None, None)
     }
 
-    if (ifBodyLine.isEmpty && (elseLine.isDefined && elseBodyLine.isEmpty)) return false
-
-    (ifLine, elseLine) match {
-      case (Some(x), None) => if (singleLineAllowed) !sameLine(ifLine, ifBodyLine) else true
-      case (Some(x), Some(y)) => {
-        if (!sameLine(ifLine, ifBodyLine) || !sameLine(elseLine, elseBodyLine)) {
-          true
-        } else {
-           if (sameLine(ifLine, elseLine)) !singleLineAllowed else !doubleLineAllowed
+    if (ifBodyLine.isEmpty && (elseLine.isDefined && elseBodyLine.isEmpty)) {
+      false
+    } else {
+      (ifLine, elseLine) match {
+        case (Some(x), None) => if (singleLineAllowed) !sameLine(ifLine, ifBodyLine) else true
+        case (Some(x), Some(y)) => {
+          if (!sameLine(ifLine, ifBodyLine) || !sameLine(elseLine, elseBodyLine)) {
+            true
+          } else {
+             if (sameLine(ifLine, elseLine)) !singleLineAllowed else !doubleLineAllowed
+          }
         }
+        case _ => false
       }
-      case _ => false
     }
   }
 


### PR DESCRIPTION
Now Scalastyle (v0.8.0, latest release) can be run on Scalastyle sources with `sbt test`.

Initial list of warnings:
- `Checker:229: File line length exceeds 160 characters`
- `Checker:232: File line length exceeds 160 characters`
- `Checker:47:8: Avoid using return`
- `Checker:107:14: Cyclomatic complexity of 12 exceeds max of 10`
- `WhitespaceEndOfLineChecker:46:8: If block needs braces`
- `Main:60:6: Cyclomatic complexity of 16 exceeds max of 10`
- `Output:72:15: Cyclomatic complexity of 14 exceeds max of 10`
- `IfBraceChecker:72:76: Avoid using return`
- `IfBraceChecker:63:6: Cyclomatic complexity of 13 exceeds max of 10`
- `ImportsChecker:231:10: Avoid using return`
- `ImportsChecker:297:8: Avoid using return`
- `ImportsChecker:299:8: Avoid using return`
- `ImportsChecker:313:8: Avoid using return`
- `ImportsChecker:361:8: Avoid using return`
- `ScalaDocChecker:188:14: Cyclomatic complexity of 22 exceeds max of 10`
- `ScalaDocChecker:229:21: If block needs braces`
- `ScalaDocChecker:243:21: If block needs braces`
- `ScalaDocChecker:259:21: If block needs braces`
- `ScalaDocChecker:271:21: If block needs braces`
- `ScalaDocChecker:188:14: Method is longer than 50 lines`
- `ScalastyleConfiguration:218:25: Cyclomatic complexity of 11 exceeds max of 10`

Default generated config is used, except disabled `ReturnChecker` (the only `return` left is one in ImportOrderChecker.checkImport) and `CyclomaticComplexityChecker` (I hope it will be enabled when #217 is fixed).
