### PR TITLE
BUGFIX Class and Object name check entire name

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -41,12 +41,12 @@
  </check>
  <check class="org.scalastyle.scalariform.ClassNamesChecker" level="warning" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+   <parameter name="regex"><![CDATA[^[A-Z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
  <check class="org.scalastyle.scalariform.ObjectNamesChecker" level="warning" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+   <parameter name="regex"><![CDATA[^[A-Z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
  <check class="org.scalastyle.scalariform.PackageObjectNamesChecker" level="warning" enabled="true">


### PR DESCRIPTION
The ClassNamesChecker and ObjectNamesChecker were not checking the entire name.  Therefore `Object`, `ObjectName` and `objectName` was passing the check, but `object` was not.  Only the first two should have passed.
