### PR TITLE
Add "exceptions" param for UnderscoreImportChecker

### DIFF
--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -339,7 +339,11 @@ Note: If you intend to enable only if expressions in the format below, disable t
  </justification>
  <example-configuration>
  <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true" />
+    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true" >
+      <parameters>
+        <parameter name="ignoreRegex">collection\.JavaConverters\._|scala\.concurrent\.duration\._</parameter>
+      </parameters>
+    </check>
  ]]>
  </example-configuration>
  </check>

--- a/src/main/scala/org/scalastyle/Main.scala
+++ b/src/main/scala/org/scalastyle/Main.scala
@@ -18,7 +18,6 @@ package org.scalastyle
 
 import java.io.File
 import java.net.URLClassLoader
-import java.util.Date
 
 import com.typesafe.config.ConfigFactory
 
@@ -104,7 +103,7 @@ object Main {
     System.exit(exitVal)
   }
 
-  private[this] def now(): Long = new Date().getTime
+  private[this] def now(): Long = System.currentTimeMillis()
 
   private[this] def execute(mc: MainConfig)(implicit codec: Codec): Boolean = {
     val start = now()

--- a/src/main/scala/org/scalastyle/scalariform/ImportsChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ImportsChecker.scala
@@ -36,6 +36,7 @@ import _root_.scalariform.parser.ExprElement
 import _root_.scalariform.parser.GeneralTokens
 import _root_.scalariform.parser.ImportClause
 import _root_.scalariform.parser.ImportSelectors
+import scala.util.matching.Regex
 
 // scalastyle:off multiple.string.literals
 
@@ -115,9 +116,18 @@ class IllegalImportsChecker extends AbstractImportChecker {
 }
 
 class UnderscoreImportChecker extends AbstractImportChecker {
+  private val DefaultIgnoreRegex = "^$"
   val errorKey = "underscore.import"
 
-  def matches(t: ImportClauseVisit): Boolean = imports(t).exists(_.endsWith("._"))
+  private var ignoreRegex: Regex = _
+
+  override protected def init(): Unit = {
+    ignoreRegex = getString("ignoreRegex", DefaultIgnoreRegex).r
+  }
+
+  def matches(t: ImportClauseVisit): Boolean = imports(t)
+      .filterNot((importStatement) => ignoreRegex.findFirstIn(importStatement).isDefined)
+      .exists(_.endsWith("._"))
 }
 
 class ImportGroupingChecker extends ScalariformChecker {

--- a/src/test/scala/org/scalastyle/scalariform/ImportsCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ImportsCheckerTest.scala
@@ -113,7 +113,7 @@ class UnderscoreImportCheckerTest extends AssertionsForJUnit with CheckerTest {
   val key = "underscore.import"
   val classUnderTest = classOf[UnderscoreImportChecker]
 
-  @Test def testNone(): Unit = {
+  @Test def testWithoutExceptions(): Unit = {
     val source = """
 package foobar
 
@@ -128,6 +128,25 @@ object Foobar {
 """
 
     assertErrors(List(columnError(5, 0), columnError(6, 0), columnError(7, 0), columnError(10, 2)), source)
+  }
+
+  @Test def testWithExceptions(): Unit = {
+    val source = """
+package foobar
+
+import java.util.List
+import java.lang._
+import collection.JavaConverters._
+import scala.concurrent.duration.{DAYS, _}
+
+object Foobar {
+  import collection.JavaConverters._
+}
+"""
+    val params = Map("ignoreRegex" -> "collection\\.JavaConverters\\._|scala\\.concurrent\\.duration\\._")
+    val expected = List(columnError(5, 0))
+
+    assertErrors(expected, source, params = params)
   }
 }
 


### PR DESCRIPTION
- New param is a comma-separated list of imports that are ignored
by the UnderscoreImportChecker
- Partially addresses #220