### PR TITLE
Documentation for classParamIndentSize in indentation checker

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -322,6 +322,8 @@ indentation.tabSize.label = "Tab size"
 indentation.tabSize.description = "Number of characters that a tab represents"
 indentation.methodParamIndentSize.label = "Multi-line method parameter spacing"
 indentation.methodParamIndentSize.description = "Level of indentation of multi-line method parameters relative to the indentation of the first line of the method"
+indentation.classParamIndentSize.label = "Multi-line class parameter spacing"
+indentation.classParamIndentSize.description = "Level of indentation of multi-line primary constructor parameters of a class. Relative to the indentation of the first line of class declaration"
 
 field.name.message = "Field name does not match the regular expression ''{0}''"
 field.name.label = "Field name"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -164,6 +164,7 @@
         <parameters>
             <parameter name="tabSize" type="integer" default="2" />
             <parameter name="methodParamIndentSize" type="integer" default="2" />
+            <parameter name="classParamIndentSize" type="integer" default="4" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.FieldNamesChecker" id="field.name" defaultLevel="warning">

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -721,6 +721,7 @@ To bring consistency with how comments should be formatted, leave a space right 
       <parameters>
         <parameter name="tabSize">2</parameter>
         <parameter name="methodParamIndentSize">2</parameter>
+        <parameter name="classParamIndentSize">4</parameter>
       </parameters>
     </check>
  ]]>


### PR DESCRIPTION
classParamIndentSize was implemented in #153 and #154

Avoid confusion with tabSize parameter default value.
It wasn't clear why indentation=2 does not work with multiline case classes without looking into scalastyle code/tests.