### PR TITLE
Addressed issue #236.

### DIFF
--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -80,9 +80,16 @@ class ScalastyleChecker[T <: FileSpec](classLoader: Option[ClassLoader] = None) 
 case class ScalariformAst(ast: CompilationUnit, comments: List[Comment])
 
 object Checker {
-  def parseLines(source: String): Lines = Lines(source.split("\n").scanLeft(Line("", 0, 0)) {
-          case (pl, t) => Line(t, pl.end, pl.end + t.length + 1)
-        }.tail, source.charAt(source.length()-1))
+  def parseLines(source: String): Lines = {
+
+    // Split lines by supported EOL sequences. Windows text files use a carriage return ("\r") immediately followed by a
+    // linefeed ("\n"), while Unix/Linux/BSD/etc. text files use just a linefeed. Other EOL sequences are currently
+    // unsupported. Note that split removes the matching regular expression, so that the array of lines excludes EOL
+    // sequences.
+    Lines(source.split("\r?\n").scanLeft(Line("", 0, 0)) {
+      case (pl, t) => Line(t, pl.end, pl.end + t.length + 1)
+    }.tail, source.charAt(source.length()-1))
+  }
 }
 
 class CheckerUtils(classLoader: Option[ClassLoader] = None) {

--- a/src/main/scala/org/scalastyle/file/HeaderMatchesChecker.scala
+++ b/src/main/scala/org/scalastyle/file/HeaderMatchesChecker.scala
@@ -31,7 +31,9 @@ class HeaderMatchesChecker extends FileChecker {
     val regexParameter = getBoolean("regex", false)
     val headerParameter = getString("header", DefaultHeader)
     if (regexParameter) {
-      val Regex = (headerParameter ++ "(?s:.*)").r
+
+      // Convert any Windows line termination sequences ("\r\n") to Unix/Linux/BSD style for consistency.
+      val Regex = (headerParameter.replaceAll("\r\n", "\n") ++ "(?s:.*)").r
       val fullSource = ast.lines map { _.text } mkString "\n"
       fullSource match {
         case Regex() =>
@@ -41,13 +43,13 @@ class HeaderMatchesChecker extends FileChecker {
       }
     } else {
       val header = Checker.parseLines(headerParameter)
-      val found = (0 to scala.math.min(ast.lines.size - 1, header.lines.size - 1)).find(i => !ast.lines(i).text.trim.equals(header.lines(i).text.trim))
+      val found = (0 until scala.math.min(ast.lines.length, header.lines.length)).find(i => !ast.lines(i).text.equals(header.lines(i).text))
 
       found match {
         case Some(x) => List(LineError(x + 1))
         case None => {
-          if (ast.lines.size < header.lines.size) {
-            List(LineError(ast.lines.size))
+          if (ast.lines.size < header.lines.length) {
+            List(LineError(ast.lines.length))
           } else {
             List()
           }

--- a/src/test/scala/org/scalastyle/file/HeaderMatchesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/HeaderMatchesCheckerTest.scala
@@ -25,95 +25,112 @@ class HeaderMatchesCheckerTest extends AssertionsForJUnit with CheckerTest {
   val key = "header.matches"
   val classUnderTest = classOf[HeaderMatchesChecker]
 
-  val licence = """/**
- * Copyright (C) 2009-2010 the original author or authors.
- * See the notice.md file distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */"""
+  val licenseLines = List(
+    "/**",
+    " * Copyright (C) 2009-2010 the original author or authors.",
+    " * See the notice.md file distributed with this work for additional",
+    " * information regarding copyright ownership.",
+    " *",
+    " * Licensed under the Apache License, Version 2.0 (the \"License\");",
+    " * you may not use this file except in compliance with the License.",
+    " * You may obtain a copy of the License at",
+    " *",
+    " *     http://www.apache.org/licenses/LICENSE-2.0",
+    " *",
+    " * Unless required by applicable law or agreed to in writing, software",
+    " * distributed under the License is distributed on an \"AS IS\" BASIS,",
+    " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    " * See the License for the specific language governing permissions and",
+    " * limitations under the License.",
+    " */"
+  )
+  val licenseUnix = licenseLines.mkString("\n")
+  val licenseWin = licenseLines.mkString("\r\n")
+
+  val baseSourceLines = List(
+    "",
+    "package foobar",
+    "",
+    "  object Foobar {",
+    "}",
+    ""
+  )
 
   @Test def testOK(): Unit = {
-    val source = licence + """
-package foobar
-
-  object Foobar {
-}
-"""
-
-    assertErrors(List(), source, Map("header" -> licence))
+    val sourceLines = licenseLines ::: baseSourceLines
+    val sourceUnix = sourceLines.mkString("\n")
+    val sourceWin = sourceLines.mkString("\r\n")
+    assertErrors(List(), sourceUnix, Map("header" -> licenseUnix))
+    assertErrors(List(), sourceWin, Map("header" -> licenseWin))
+    assertErrors(List(), sourceUnix, Map("header" -> licenseWin))
+    assertErrors(List(), sourceWin, Map("header" -> licenseUnix))
   }
 
   @Test def testKO(): Unit = {
-    val source = licence.replaceAll("BASIS,", "XXX") + """
-package foobar
+    val sourceLines = licenseLines ::: baseSourceLines
+    val sourceUnix = sourceLines.mkString("\n").replaceAll("BASIS,", "XXX")
+    val sourceWin = sourceLines.mkString("\r\n").replaceAll("BASIS,", "XXX")
 
-  object Foobar {
-}
-"""
-
-    assertErrors(List(lineError(13)), source, Map("header" -> licence))
+    assertErrors(List(lineError(13)), sourceUnix, Map("header" -> licenseUnix))
+    assertErrors(List(lineError(13)), sourceWin, Map("header" -> licenseWin))
+    assertErrors(List(lineError(13)), sourceUnix, Map("header" -> licenseWin))
+    assertErrors(List(lineError(13)), sourceWin, Map("header" -> licenseUnix))
   }
 
   @Test def testTooShort(): Unit = {
-    val source = """/**
- * Copyright (C) 2009-2010 the original author or authors.
- * See the notice.md file distributed with this work for additional
- * information regarding copyright ownership."""
-
-    assertErrors(List(lineError(4)), source, Map("header" -> licence))
+    val shortSourceLines = licenseLines.take(4)
+    val shortSourceUnix = shortSourceLines.mkString("\n")
+    val shortSourceWin = shortSourceLines.mkString("\r\n")
+    assertErrors(List(lineError(4)), shortSourceUnix, Map("header" -> licenseUnix))
+    assertErrors(List(lineError(4)), shortSourceWin, Map("header" -> licenseWin))
+    assertErrors(List(lineError(4)), shortSourceUnix, Map("header" -> licenseWin))
+    assertErrors(List(lineError(4)), shortSourceWin, Map("header" -> licenseUnix))
   }
 
-  val licenceRegex = {
-    def literalOK(c: Char): Boolean = c match {
-      case ' '|'-'|':'|'/'|'\n' => true
-      case ld: Any if ld.isLetterOrDigit => true
-      case _ => false
-    }
-    (licence flatMap { c => if (literalOK(c)) c.toString else "\\" + c}).replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
+  def literalOK(c: Char): Boolean = c match {
+    case ' '|'-'|':'|'/'|'\n' => true
+    case ld: Any if ld.isLetterOrDigit => true
+    case _ => false
+  }
+
+  val licenceRegexUnix = {
+    (licenseUnix flatMap { c => if (literalOK(c)) c.toString else "\\" + c}).replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
+  }
+  val licenceRegexWin = {
+    (licenseWin flatMap { c => if (literalOK(c)) c.toString else "\\" + c}).replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
   }
 
   @Test def testRegexOK(): Unit = {
-    val source = licence + """
-package foobar
+    val sourceLines = licenseLines ::: baseSourceLines
+    val sourceUnix = sourceLines.mkString("\n")
+    val sourceWin = sourceLines.mkString("\r\n")
 
-  object Foobar {
-}
-"""
-
-    assertErrors(List(), source, Map("header" -> licenceRegex, "regex" -> "true"))
+    assertErrors(List(), sourceUnix, Map("header" -> licenceRegexUnix, "regex" -> "true"))
+    assertErrors(List(), sourceWin, Map("header" -> licenceRegexWin, "regex" -> "true"))
+    assertErrors(List(), sourceUnix, Map("header" -> licenceRegexWin, "regex" -> "true"))
+    assertErrors(List(), sourceWin, Map("header" -> licenceRegexUnix, "regex" -> "true"))
   }
 
   @Test def testRegexFlexible(): Unit = {
-    val source = licence.replace("2009-2010", "2009-2014") + """
-package foobar
+    val sourceLines = licenseLines ::: baseSourceLines
+    val sourceUnix = sourceLines.mkString("\n").replace("2009-2010", "2009-2014")
+    val sourceWin = sourceLines.mkString("\r\n").replace("2009-2010", "2009-2014")
 
-  object Foobar {
-}
-"""
-
-    assertErrors(List(), source, Map("header" -> licenceRegex, "regex" -> "true"))
+    assertErrors(List(), sourceUnix, Map("header" -> licenceRegexUnix, "regex" -> "true"))
+    assertErrors(List(), sourceWin, Map("header" -> licenceRegexWin, "regex" -> "true"))
+    assertErrors(List(), sourceUnix, Map("header" -> licenceRegexWin, "regex" -> "true"))
+    assertErrors(List(), sourceWin, Map("header" -> licenceRegexUnix, "regex" -> "true"))
   }
 
   @Test def testRegexKO(): Unit = {
-    val source = licence.replace("2009-2010", "xxxx-xxxx") + """
-package foobar
+    val sourceLines = licenseLines ::: baseSourceLines
+    val sourceUnix = sourceLines.mkString("\n").replace("2009-2010", "xxxx-xxxx")
+    val sourceWin = sourceLines.mkString("\r\n").replace("2009-2010", "xxxx-xxxx")
 
-  object Foobar {
-}
-"""
-
-    assertErrors(List(fileError()), source, Map("header" -> licenceRegex, "regex" -> "true"))
+    assertErrors(List(fileError()), sourceUnix, Map("header" -> licenceRegexUnix, "regex" -> "true"))
+    assertErrors(List(fileError()), sourceWin, Map("header" -> licenceRegexWin, "regex" -> "true"))
+    assertErrors(List(fileError()), sourceUnix, Map("header" -> licenceRegexWin, "regex" -> "true"))
+    assertErrors(List(fileError()), sourceWin, Map("header" -> licenceRegexUnix, "regex" -> "true"))
   }
 
 }


### PR DESCRIPTION
Checker.parseLines now recognizes Windows - as well as Unix/Linux/BSD -
text file line endings.

Added tests to HeaderMatchesCheckerTest that verify headers and sources
in all combinations of the two text formats.

Removed "trim" from HeaderMatchesChecker non-regex header check (since
this removes leading/trailing whitespace before comparison, potentially
leading to false positive header matches. (Admittedly, this may change
some codebase's successes to failures.)