### PR TITLE
WIP: Addressed issue #204

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -77,7 +77,11 @@
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true">
+  <parameters>
+   <parameter name="allowNullChecks"><![CDATA[true]]></parameter>
+  </parameters>
+ </check>
  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -92,6 +92,7 @@ return.description = "Check that return is not used"
 null.message = "Avoid using null"
 null.label = "Null"
 null.description = "Check that null is not used"
+null.allowNullChecks.description = "Allow occurrences in checks like 'x == null' or 'x != null'"
 
 no.clone.message = "Avoid using clone method."
 no.clone.label = "Clone method"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -65,7 +65,11 @@
     <checker class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" id="no.whitespace.before.left.bracket" defaultLevel="warning" />
     <checker class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" id="no.whitespace.after.left.bracket" defaultLevel="warning" />
     <checker class="org.scalastyle.scalariform.ReturnChecker" id="return" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.NullChecker" id="null" defaultLevel="warning" />
+    <checker class="org.scalastyle.scalariform.NullChecker" id="null" defaultLevel="warning">
+        <parameters>
+            <parameter name="allowNullChecks" type="boolean" default="true" />
+        </parameters>
+    </checker>
     <checker class="org.scalastyle.scalariform.NoCloneChecker" id="no.clone" defaultLevel="warning" />
     <checker class="org.scalastyle.scalariform.NoFinalizeChecker" id="no.finalize" defaultLevel="warning" />
     <checker class="org.scalastyle.scalariform.CovariantEqualsChecker" id="covariant.equals" defaultLevel="warning" />

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -653,7 +653,11 @@ To bring consistency with how comments should be formatted, leave a space right 
  </justification>
  <example-configuration>
  <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true" />
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true">
+      <parameters>
+        <parameter name="allowNullChecks">true</parameter>
+      </parameters>
+    </check>
  ]]>
  </example-configuration>
  </check>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -89,6 +89,7 @@ return.description = Check that return is not used
 null.message = Avoid using null
 null.label = Null
 null.description = Check that null is not used
+null.allowNullChecks.description = Allow occurrences in checks like ''x == null'' or ''x != null''
 
 no.clone.message = Avoid using clone method.
 no.clone.label = Clone method

--- a/src/test/resources/config/scalastyle_config.xml
+++ b/src/test/resources/config/scalastyle_config.xml
@@ -59,7 +59,11 @@
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true">
+  <parameters>
+   <parameter name="allowNullChecks"><![CDATA[true]]></parameter>
+  </parameters>
+ </check>
  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>

--- a/src/test/scala/org/scalastyle/scalariform/NullCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NullCheckerTest.scala
@@ -50,4 +50,20 @@ object Foobar {
 
     assertErrors(List(columnError(5, 20), columnError(6, 20)), source)
   }
+
+  @Test def testTwo(): Unit = {
+    val source = """
+package foobar
+
+object Foobar {
+  def bar(s: String): Int = {
+    if (s == null) 0
+    else if (s != null) 1
+    else 2
+  }
+}
+"""
+
+    assertErrors(List(), source)
+  }
 }


### PR DESCRIPTION
The NullChecker takes a parameter allowNullChecks (which defaults to true)
indicating that 'null' is tolerated in the code if it is preceded by
equality '==' or inequality '!='.

Added a test which covers both above cases.