### PR TITLE
Add OverrideJavaChecker rule

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -135,6 +135,7 @@
   </parameters>
  </check>
  <check class="org.scalastyle.scalariform.DeprecatedJavaChecker" level="warning" enabled="true"></check>
+ <check class="org.scalastyle.scalariform.OverrideJavaChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.EmptyClassChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.ClassTypeParameterChecker" level="warning" enabled="true">
   <parameters>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -232,6 +232,10 @@ deprecated.java.message = "@deprecated should be used instead of @java.lang.Depr
 deprecated.java.label = "No use of Java @Deprecated"
 deprecated.java.description = "Checks that Java @Deprecated is not used, Scala @deprecated should be used instead"
 
+override.java.message = "You should be using the Scala override keyword instead"
+override.java.label = "No use of Java @Override"
+override.java.description = "Checks that Java @Override is not used"
+
 empty.class.message = "Redundant braces after class definition"
 empty.class.label = "Redundant braces in class definition"
 empty.class.description = "If a class/trait has no members, the braces are unnecessary"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -139,6 +139,7 @@
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.DeprecatedJavaChecker" id="deprecated.java" defaultLevel="warning"/>
+    <checker class="org.scalastyle.scalariform.OverrideJavaChecker" id="override.java" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.EmptyClassChecker" id="empty.class" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.ClassTypeParameterChecker" id="class.type.parameter.name" defaultLevel="warning" >
         <parameters>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -321,6 +321,17 @@ Note: If you intend to enable only if expressions in the format below, disable t
  </example-configuration>
  </check>
 
+ <check id="override.java">
+  <justification>
+   You should be using the Scala override keyword instead.
+  </justification>
+  <example-configuration>
+   <![CDATA[
+    <check level="warning" class="org.scalastyle.scalariform.OverrideJavaChecker enabled="true" />
+ ]]>
+  </example-configuration>
+ </check>
+
  <check id="empty.class">
  <justification>
  If a class / trait has no members, then braces are unnecessary, and can be removed.

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -227,6 +227,10 @@ deprecated.java.message = @deprecated should be used instead of @java.lang.Depre
 deprecated.java.label = No use of Java @Deprecated
 deprecated.java.description = Checks that Java @Deprecated is not used, Scala @deprecated should be used instead
 
+override.java.message = You should be using the Scala override keyword instead
+override.java.label = No use of Java @Override
+override.java.description = Checks that Java @Override is not used
+
 empty.class.message = Redundant braces after class definition
 empty.class.label = Redundant braces in class definition
 empty.class.description = If a class/trait has no members, the braces are unnecessary

--- a/src/main/scala/org/scalastyle/scalariform/JavaAnnotationChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/JavaAnnotationChecker.scala
@@ -23,14 +23,13 @@ import org.scalastyle.ScalastyleError
 import _root_.scalariform.parser.CompilationUnit
 import _root_.scalariform.parser.{Annotation => ParserAnnotation}
 
-class DeprecatedJavaChecker extends ScalariformChecker {
-  val errorKey = "deprecated.java"
-  val deprecatedTokens = List("Deprecated", "java.lang.Deprecated")
+abstract class JavaAnnotationChecker extends ScalariformChecker {
+  val invalidTokens: List[String]
 
   final def verify(ast: CompilationUnit): List[ScalastyleError] = {
     val it = for {
       t <- VisitorHelper.getAll[ParserAnnotation](ast.immediateChildren.head)
-      if isDeprecated(t)
+      if isValid(t)
     } yield {
       PositionError(t.firstToken.offset)
     }
@@ -38,8 +37,18 @@ class DeprecatedJavaChecker extends ScalariformChecker {
     it
   }
 
-  private def isDeprecated(t: ParserAnnotation) = {
+  def isValid(t: ParserAnnotation): Boolean = {
     val text = t.annotationType.tokens.foldLeft("")((x, y) => x + y.text)
-    t.annotationType.tokens.nonEmpty && deprecatedTokens.contains(text)
+    t.annotationType.tokens.nonEmpty && invalidTokens.contains(text)
   }
+}
+
+class DeprecatedJavaChecker extends JavaAnnotationChecker {
+  val errorKey = "deprecated.java"
+  val invalidTokens = List("Deprecated", "java.lang.Deprecated")
+}
+
+class OverrideJavaChecker extends JavaAnnotationChecker {
+  val errorKey = "override.java"
+  val invalidTokens = List("Override", "java.lang.Override")
 }

--- a/src/test/scala/org/scalastyle/scalariform/JavaAnnotationCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/JavaAnnotationCheckerTest.scala
@@ -20,8 +20,6 @@ import org.junit.Test
 import org.scalastyle.file.CheckerTest
 import org.scalatest.junit.AssertionsForJUnit
 
-// scalastyle:off magic.number
-
 class DeprecatedJavaCheckerTest extends AssertionsForJUnit with CheckerTest {
   val key = "deprecated.java"
   val classUnderTest = classOf[DeprecatedJavaChecker]
@@ -49,5 +47,28 @@ class OK {
 """
 
     assertErrors(List(columnError(5, 2), columnError(8, 2), columnError(11, 2), columnError(14, 2)), source)
+  }
+}
+
+class OverrideJavaCheckerTest extends AssertionsForJUnit with CheckerTest {
+  val key = "override.java"
+  val classUnderTest = classOf[OverrideJavaChecker]
+
+  @Test def testClassOK(): Unit = {
+    val source = """
+package foobar
+
+class FooBar {
+  @Override
+  def fun() = 1
+
+  @java.lang.Override
+  def fun2() = 2
+
+  override def fun3() = 3
+}
+"""
+
+    assertErrors(List(columnError(5, 2), columnError(8, 2)), source)
   }
 }


### PR DESCRIPTION
JavaAnnotationChecker abstract class is introduced as a base for
both DeprecatedJavaChecker and OverrideJavaChecker classes.