### PR TITLE
Add parameter ignoreComments to MethodLengthChecker

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -114,6 +114,7 @@
  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLength"><![CDATA[50]]></parameter>
+   <parameter name="ignoreComments"><![CDATA[false]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -167,6 +167,8 @@ method.length.label = "Method length"
 method.length.description = "Checks that methods do not exceed a maximum length"
 method.length.maxLength.label = "Maximum length"
 method.length.maxLength.description = "Maximum number of lines allowed for a method"
+method.length.ignoreComments.label = "Ignore comments"
+method.length.ignoreComments.description = "If set to true, comment lines in method body won't be counted"
 
 method.name.message = "Method name does not match the regular expression ''{0}''"
 method.name.label = "Method name"
@@ -360,4 +362,4 @@ todo.comment.words.description = "Alternative list of words to look for, separat
 
 empty.interpolated.strings.message = "Unnecessary use of interpolated string"
 empty.interpolated.strings.label = "Empty interpolated string"
-empty.interpolated.strings.description = "The interpolation for this string literal is not nessescary"
+empty.interpolated.strings.description = "The interpolation for this string literal is not necessary"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -102,6 +102,7 @@
     <checker class="org.scalastyle.scalariform.MethodLengthChecker" id="method.length" defaultLevel="warning" >
         <parameters>
             <parameter name="maxLength" type="integer" default="50" />
+            <parameter name="ignoreComments" type="boolean" default="false" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.MethodNamesChecker" id="method.name" defaultLevel="warning" >

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -158,6 +158,7 @@ Note: If you intend to enable only if expressions in the format below, disable t
     <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
       <parameters>
         <parameter name="maxLength">50</parameter>
+        <parameter name="ignoreComments">false</parameter>
       </parameters>
     </check>
  ]]>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -162,6 +162,8 @@ method.length.label = Method length
 method.length.description = Checks that methods do not exceed a maximum length
 method.length.maxLength.label = Maximum length
 method.length.maxLength.description = Maximum number of lines allowed for a method
+method.length.ignoreComments.label = "Ignore comments"
+method.length.ignoreComments.description = "If set to true, comment lines in method body won't be counted"
 
 method.name.message = Method name does not match the regular expression ''{0}''
 method.name.label = Method name


### PR DESCRIPTION
This PR is for https://github.com/scalastyle/scalastyle/issues/247 and https://github.com/scalastyle/scalastyle/issues/166

Add a parameter `ignoreComments` to `MethodLengthCheker`
If this flag is set to true, `MethodLengthChecker` won't be count comment line.

---

This PR won't change default behavior of MethodLengthChecke.
`ignoreComments` is optional and, by default, it is set to false.