### PR TITLE
Fixes #260 - Not all interpolation types require variables

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/EmptyInterpolatedStringChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/EmptyInterpolatedStringChecker.scala
@@ -24,11 +24,13 @@ import _root_.scalariform.parser.CompilationUnit
 class EmptyInterpolatedStringChecker extends ScalariformChecker {
   val errorKey = "empty.interpolated.strings"
   val interpolationRegex = """.*\$""".r
+  val typesSupportingVariables = Set("s", "f")
 
   def verify(ast: CompilationUnit): List[ScalastyleError] = {
     val it = for {
         List(left, right) <- ast.tokens.sliding(2)
-        if left.tokenType == INTERPOLATION_ID && interpolationRegex.findFirstIn(right.text).isEmpty
+        if left.tokenType == INTERPOLATION_ID && typesSupportingVariables.contains(left.text) &&
+          interpolationRegex.findFirstIn(right.text).isEmpty
       } yield {
         PositionError(right.offset)
       }

--- a/src/test/scala/org/scalastyle/scalariform/EmptyInterpolatedStringCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/EmptyInterpolatedStringCheckerTest.scala
@@ -86,4 +86,17 @@ class Foobar {
 """
     assertErrors(List(columnError(5, 13), columnError(6, 13), columnError(8, 13)), source)
   }
+
+  @Test def testRaw(): Unit = {
+    val source = """
+package foobar
+
+class Foobar {
+  val foo = s"foo"
+  val bar = raw"test"
+}
+"""
+    assertErrors(List(columnError(5, 13)), source)
+
+  }
 }


### PR DESCRIPTION
So instead, only check if s or f are being used