### PR TITLE
Address Issue #266.

### DIFF
--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -166,9 +166,9 @@
     <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning">
         <parameters>
             <parameter name="ignoreRegex" type="string" default="^$"/>
-						<parameter name="ignoreTokenTypes" type="string" default="^$"/>
+            <parameter name="ignoreTokenTypes" type="string" default="^$"/>
             <parameter name="ignoreOverride" type="boolean" default="false"/>
-            <parameter name="indentStyle" type="string" default=""/>
+            <parameter name="indentStyle" type="string" default="anydoc"/>
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" id="disallow.space.after.token" defaultLevel="warning"/>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -892,6 +892,7 @@ Warning: This check can also wrongly pick up type lamdbas and other such constru
  </justification>
  <extra-description>
  Ignore tokens is a comma separated string that may include the following : PatDefOrDcl (variables), TmplDef (classes, traits), TypeDefOrDcl (type definitions), FunDefOrDcl (functions)
+ Supported indentation styles are "scaladoc" (for ScalaDoc-style comments, with two spaces before the asterisk), "javadoc" (for JavaDoc-style comments, with a single space before the asterisk) or "anydoc" to support any style (any number of spaces before the asterisk). For backwards compatibility, if left empty, "anydoc" will be assumed.
  </extra-description>
  <example-configuration>
  <![CDATA[
@@ -899,8 +900,8 @@ Warning: This check can also wrongly pick up type lamdbas and other such constru
       <parameters>
         <parameter name="ignoreRegex">(.*Spec$)|(.*SpecIT$)</parameter>
         <parameter name="ignoreTokenTypes">PatDefOrDcl,TypeDefOrDcl,FunDefOrDcl,TmplDef</parameter>
-        <parameter name="ignoreOverride" type="boolean" default="false" />
-        <parameter name="indentStyle" type="string" default=""/>
+        <parameter name="ignoreOverride">false</parameter>
+        <parameter name="indentStyle">anydoc</parameter>
       </parameters>
     </check>
  ]]>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -306,8 +306,7 @@ scaladoc.ignoreTokenTypes.description = "Include the following to ignore : PatDe
 scaladoc.ignoreOverride.label = Ignore override
 scaladoc.ignoreOverride.description = If set to true, methods which have the override modifier are ignored
 scaladoc.indentStyle.label = Indent style
-scaladoc.indentStyle.description = Possible values: scaladoc - 2 spaces before *, javadoc - 1 space before *
-
+scaladoc.indentStyle.description = Possible values: scaladoc - 2 spaces before asterisk, javadoc - 1 space before asterisk, anydoc - any number of spaces before asterisk.
 indentation.message = Use correct indentation
 indentation.label = Use correct indentation
 indentation.description = Checks that lines are indented by a multiple of the tab size

--- a/src/main/scala/org/scalastyle/scalariform/ScalaDocChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ScalaDocChecker.scala
@@ -349,10 +349,11 @@ object ScalaDocChecker {
   object AnyDocStyle extends DocIndentStyle
   object UndefinedDocStyle extends DocIndentStyle
 
-  def getStyleFrom(name: String): DocIndentStyle = name match {
+  def getStyleFrom(name: String): DocIndentStyle = name.toLowerCase match {
     case "scaladoc" => ScalaDocStyle
     case "javadoc" => JavaDocStyle
-    case _ => AnyDocStyle
+    case "anydoc" | "" => AnyDocStyle
+    case _ => throw new RuntimeException(s"Unsupported ScalaDocChecker indentStyle: '$name'")
   }
 
   /**


### PR DESCRIPTION
Third - and final - attempt. ;-)

Corrects ScalaDocChecker configuration documentation, as described in #266.

Also enforced use of "scaladoc", "javadoc", "anydoc" or "" as indentStyle parameter values. (Comparisons are case-insensitive.) The default style was changed to be "anydoc" instead of "", which looks less confusing in the documentation. However, "" was retained for backwards compatibility.

Note: There doesn't appear to be a mechanism for reporting errors in Scalastyle configuration files, so I have lamely just thrown a RuntimeException. This does the job - albeit with a non-internationalized error message - but if you have a more elegant approach, please let me know.

This supersedes PRs #268 & #269.