### PR TITLE
NonASCIICharacterChecker should inspect Token.rawText, not Token.text

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/NonASCIICharacterChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/NonASCIICharacterChecker.scala
@@ -16,7 +16,6 @@
 
 package org.scalastyle.scalariform
 
-
 import java.util.regex.Pattern
 
 import org.scalastyle.PositionError
@@ -28,13 +27,12 @@ import _root_.scalariform.parser.CompilationUnit
 
 class NonASCIICharacterChecker extends ScalariformChecker {
   val errorKey: String = "non.ascii.character.disallowed"
+  private val asciiPattern = Pattern.compile("""\p{ASCII}+""", Pattern.DOTALL)
 
   override def verify(ast: CompilationUnit): List[ScalastyleError] = {
     ast.tokens.filter(hasNonAsciiChars).map(x => PositionError(x.offset))
   }
 
   private def hasNonAsciiChars(x: Token) =
-    x.text.trim.nonEmpty && !Pattern.compile( """\p{ASCII}+""", Pattern.DOTALL)
-      .matcher(x.text.trim).matches()
-
+    x.rawText.trim.nonEmpty && !asciiPattern.matcher(x.rawText.trim).matches()
 }

--- a/src/test/scala/org/scalastyle/scalariform/NonASCIICharacterCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NonASCIICharacterCheckerTest.scala
@@ -39,8 +39,18 @@ class NonASCIICharacterCheckerTest extends AssertionsForJUnit with CheckerTest {
     assertErrors(List(), source)
   }
 
+  @Test def testStringOK(): Unit = {
+    val source = """
+                   |package foobar
+                   |// non-ascii in string via unicode escape - ok
+                   |class OK {
+                   |  val s = "%s"
+                   |}""".stripMargin.format("\\ud83c\\udf4e")
 
-  @Test def testClassNotOk(): Unit = {
+    assertErrors(List(), source)
+  }
+
+  @Test def testClassNotOK(): Unit = {
     val source = """
                    |package foobar
                    |// \u2190
@@ -49,6 +59,18 @@ class NonASCIICharacterCheckerTest extends AssertionsForJUnit with CheckerTest {
                    |  def `\u21d2` = "test"
                    |}
                    | """.stripMargin
+
     assertErrors(List(columnError(2, 14), columnError(5, 6), columnError(6, 6)), source)
+  }
+
+  @Test def testStringNotOK(): Unit = {
+    val source = """
+                   |package foobar
+                   |// non-ascii literal in string - not ok
+                   |class NotOK {
+                   |  val s = "\ud83c\udf4e"
+                   |}""".stripMargin
+
+    assertErrors(List(columnError(5, 10)), source)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/scalastyle/scalastyle/issues/273

Per [Token.scala](https://github.com/scala-ide/scalariform/blob/e3160528a906e5117ce05e867b340b504e522c76/scalariform/src/main/scala/scalariform/lexer/Token.scala#L6-L11):

```
 * @param text -- the text associated with the token after unicode escaping
 * @param rawText -- the text associated with the token before unicode escaping
```

NonASCIICharacterChecker currently looks at `text` (source code with escapes sequences applied), it should look at `rawText` (source code in raw form).