### PR TITLE
Add scala.Any and Object to the list of "object" types

### DIFF
--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -237,7 +237,8 @@ trait Checker[A] {
 
   def verify(ast: A): List[ScalastyleError]
 
-  protected def isObject(s: String): Boolean = s == "java.lang.Object" || s == "Any"
+  protected def isObject(s: String): Boolean =
+    s == "java.lang.Object" || s == "Any" || s == "scala.Any" || s == "Object"
   protected def isNotObject(s: String): Boolean = !isObject(s)
 }
 


### PR DESCRIPTION
This addresses #281, as discussed in [gitter](https://gitter.im/scalastyle/scalastyle?at=59d759bef7299e8f53b55b56).