### PR TITLE
Fix #277, avoid unexpected ScalaDocChecker warning for implicit def

### DIFF
--- a/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ScalaDocCheckerTest.scala
@@ -465,4 +465,30 @@ class ScalaDocCheckerTest extends AssertionsForJUnit with CheckerTest {
     assertErrors(List.empty, source,
       Map("indentStyle" -> "javadoc"))
   }
+
+  @Test def indentImplicitDefScalaOrJavaDoc(): Unit = {
+    // refer: https://github.com/scalastyle/scalastyle/issues/277
+    val sourceScalaDoc =
+      """
+        | object X {
+        |   /**
+        |     *
+        |     */
+        |   implicit def test = 1
+        | }
+      """.stripMargin
+    assertErrors(List.empty, sourceScalaDoc, Map("indentStyle" -> "scaladoc"))
+
+    val sourceJavaDoc =
+      """
+        | object X {
+        |   /**
+        |    *
+        |    */
+        |   implicit def test = 1
+        | }
+      """.stripMargin
+
+    assertErrors(List.empty, sourceJavaDoc, Map("indentStyle" -> "javadoc"))
+  }
 }


### PR DESCRIPTION
Fix #277

---

#277 seems to be scalariform's bug.

https://github.com/scalastyle/scalastyle/blob/47bae5da4e02fdc4e2efe437ab493617c8ddb68c/src/main/scala/org/scalastyle/scalariform/ScalaDocChecker.scala#L106-L114


`token.associatedWhitespaceAndComments` in `findScalaDoc` method normally return the HiddenToken contains Whitespace (before ScalaDoc comment) token and MULTILINE_COMMENT token, and [we can get `commentOffset` checking the Whitespace length](https://github.com/scalastyle/scalastyle/blob/47bae5da4e02fdc4e2efe437ab493617c8ddb68c/src/main/scala/org/scalastyle/scalariform/ScalaDocChecker.scala#L108-L109) .
But when checking scaladoc for implicit function definition, `token.associatedWhitesaceAndComments` return HIddenToken contains only MULTILINE_COMMENT token, **not contains Whitespace token**.

So, when checking scaladoc for implicit function definition `HiddenTokens(ht.tokens.takeWhile(_.token != commentToken))` returns empty HiddenToken and commentOffset must be 0.
As a result, `ScalaDoc.apply(...)` have wrong indentStyle and cause unexpected warnings like #277.

I don't understand why scalariform parser return such result, and fix the issue by stop depending on the non-stable scalariform parser's parse result.