### PR TITLE
Include Regex Parameter to HeaderMatchesChecker in Parameter Table

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -33,6 +33,8 @@ header.matches.label = "Match Header"
 header.matches.description = "Check the first lines of each file matches the text"
 header.matches.header.label = "Header"
 header.matches.header.description = "The lines to compare against"
+header.matches.regex.label = "Header Regex"
+header.matches.regex.description = "Whether to treat the header string as a regular expression"
 
 spaces.after.plus.message = "There should be a space after the plus (+) sign"
 spaces.after.plus.label = "Space after plus"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -10,6 +10,7 @@
     <checker class="org.scalastyle.file.HeaderMatchesChecker" id="header.matches" defaultLevel="warning">
         <parameters>
             <parameter name="header" type="string" multiple="true" default=""/>
+            <parameter name="regex" type="boolean" default="false" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.SpacesAfterPlusChecker" id="spaces.after.plus" defaultLevel="warning" />

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -33,6 +33,8 @@ header.matches.label = Match Header
 header.matches.description = Check the first lines of each file matches the text
 header.matches.header.label = Header
 header.matches.header.description = The lines to compare against
+header.matches.regex.label = Header Regex
+header.matches.regex.description = Whether to treat the header string as a regular expression
 
 spaces.after.plus.message = There should be a space after the plus (+) sign
 spaces.after.plus.label = Space after plus


### PR DESCRIPTION
#### Changes:
- Add the undocumented `regex` parameter used by `HeaderMatchesChecker` to the scalastyle definition file

I found it odd that the `regex` parameter doesn't appear in the parameter table for `HeaderMatchesChecker` despite the examples using it. I think this should fix that, but let me know if I'm mistaken.