### PR TITLE
make MagicNumberChecker ignore param tolerate spaces

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/MagicNumberChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/MagicNumberChecker.scala
@@ -37,7 +37,7 @@ class MagicNumberChecker extends ScalariformChecker {
   val errorKey = "magic.number"
 
   def verify(ast: CompilationUnit): List[ScalastyleError] = {
-    val ignores = getString("ignore", DefaultIgnore).split(",").toSet
+    val ignores = getString("ignore", DefaultIgnore).split(",").map(_.trim).toSet
 
     val intList = for {
       t <- localvisit(ast.immediateChildren.head)

--- a/src/test/scala/org/scalastyle/scalariform/MagicNumberCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/MagicNumberCheckerTest.scala
@@ -135,4 +135,19 @@ class Foobar {
 
     assertErrors(List(columnError(5, 13), columnError(6, 13), columnError(7, 13), columnError(8, 16), columnError(8, 20), columnError(9, 20)), source)
   }
+
+  @Test def testIgnoreParamShouldTolerateSpaces(): Unit = {
+    val source = """
+package foobar
+
+class Foobar {
+
+  var fooOk: Long = 1
+  var fooFail: Long = 100L
+}
+                 """
+
+    assertErrors(List(), source, params = Map("ignore" -> "-1,0,1,2,100 "))
+  }
+
 }


### PR DESCRIPTION
When specifying a custom `ignore` parameter for MagicNumberChecker it is easy to type extra spaces. When it happens, value with a space does not get ignored, like ` 100` here:

```
 <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
  <parameters>
   <parameter name="ignore"><![CDATA[-1,0,1,2, 100]]></parameter>
  </parameters>
 </check>
``` 