### PR TITLE
Allowing no return types in methods which just call a constructor

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/PublicMethodsHaveTypeChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/PublicMethodsHaveTypeChecker.scala
@@ -16,7 +16,7 @@
 
 package org.scalastyle.scalariform
 
-import scalariform.parser.ProcFunBody
+import scalariform.parser.{Expr, ExprFunBody, New, ProcFunBody}
 
 case class PublicMethodsHaveTypeParameters(ignoreOverride: Boolean)
 
@@ -32,6 +32,7 @@ class PublicMethodsHaveTypeChecker extends AbstractSingleMethodChecker[PublicMet
         // When funBodyOpt is None, it is assumed to be a declaration of a procedure.
         // Unit return type is not required.
         false
+      case Some(ExprFunBody(_, _, Expr(New(_, _) :: _))) => false
       case _ => t.funDefOrDcl.returnTypeOpt.isEmpty && !privateOrProtected(t.fullDefOrDcl.modifiers) &&
                            !isConstructor(t.fullDefOrDcl.defOrDcl) &&
                            !(p.ignoreOverride && isOverride(t.fullDefOrDcl.modifiers)) && !t.insideDefOrValOrVar

--- a/src/test/scala/org/scalastyle/scalariform/PublicMethodsHaveTypeCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/PublicMethodsHaveTypeCheckerTest.scala
@@ -48,7 +48,7 @@ class OK {
 """
 
     assertErrors(List(columnError(5, 6), columnError(7, 6), columnError(13, 6),
-                        columnError(16, 6), columnError(17, 6)), source)
+                        columnError(16, 6)), source)
   }
 
   @Test def testProc(): Unit = {
@@ -56,6 +56,7 @@ class OK {
 class classOK {
   def proc1 {}
   def proc2(): Unit = {}
+  def proc3() = new scala.collection.mutable.HashMap()
 }
 
 abstract class abstractOK {


### PR DESCRIPTION
Fixes #294, allowing a method like this:
```
 def createSomething() = new Resource()
```
without defining an explicit return type for the method.
Used in contexts like Spring Bean definition, e.g.
```
  @Bean def database() = new PreciousDatabase(postgresDataSource())
```
