### PR TITLE
RedundantIfChecker handles booleans in braces

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/RedundantIfChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/RedundantIfChecker.scala
@@ -30,6 +30,8 @@ import _root_.scalariform.parser.ElseClause
 import _root_.scalariform.parser.Expr
 import _root_.scalariform.parser.GeneralTokens
 import _root_.scalariform.parser.IfExpr
+import _root_.scalariform.parser.BlockExpr
+import _root_.scalariform.parser.StatSeq
 
 class RedundantIfChecker extends CombinedChecker {
   val errorKey = "if.redundant"
@@ -54,12 +56,13 @@ class RedundantIfChecker extends CombinedChecker {
   }
   private def isBoolean(t: Expr): Boolean = t match {
     case Expr(List(GeneralTokens(List(a)))) => isBoolean(a)
+    case Expr(List(BlockExpr(_, Right(StatSeq(None, Some(Expr(List(GeneralTokens(List(a))))) , List())), _))) => isBoolean(a)
     case _ => false
   }
   private def isBoolean(t: Token): Boolean = Set(TRUE, FALSE).contains(t.tokenType)
 
   private def localvisit(ast: Any): List[IfExpr] = ast match {
-    case t: IfExpr if matches(t) => List(t)
+    case t: IfExpr => List(t) ++ localvisit(t.body) ++ localvisit(t.elseClause.map(_.elseBody))
     case t: Any => visit(t, localvisit)
   }
 }

--- a/src/test/scala/org/scalastyle/scalariform/RedundantIfCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/RedundantIfCheckerTest.scala
@@ -43,9 +43,16 @@ object Foobar {
       if (b1) true
       else if (b2) true
       else false
+  val b7 =
+      if (b1) {
+       true
+      }
+      else {
+       false
+      }
 }"""
 
-    assertErrors(List(columnError(6, 11), columnError(7, 11), columnError(9, 6), columnError(12, 20), columnError(15, 11)), source)
+    assertErrors(List(columnError(6, 11), columnError(7, 11), columnError(9, 6), columnError(12, 20), columnError(15, 11), columnError(18, 6)), source)
   }
 
   @Test def testOk(): Unit = {
@@ -59,6 +66,7 @@ object Foobar {
       if (b1) true
       else if (!b1 && b2) false
       else !b1
+  if (b1) { someStatement(); }
 }"""
 
     assertErrors(List(), source)


### PR DESCRIPTION
1. Enhances `RedundantIfChecker` to raise violations also when the `true`/`false` statements are in braces, e.g.
```
if (b1) {
false
} else {
true
}
```
2. Changed the `localVisit` visitor pattern logic, not to call the `matches()` immediately - as that caused duplicates. The whole purpose of the `localVisit` method is to traverse the AST tree and get all `IfExpr`. And only then, the `for` loop in `verify` method applies `matches()` on each of them, right?
3. Added a simple test case for `if` without `else`