### PR TITLE
Throwing exception when checker fails to run

### DIFF
--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -191,8 +191,7 @@ class CheckerUtils(classLoader: Option[ClassLoader] = None) {
       Some(c)
     } catch {
       case e: Exception =>
-        // TODO log something here
-        None
+        throw new RuntimeException(s"Failed to run checker $name", e)
       }
     }
   }


### PR DESCRIPTION
Scalastyle checker silently swallows exceptions, e.g. Scalastyle runs fine with the following configuration file reporting no errors:
```
<scalastyle>
  <name>Scalastyle configuration</name>
  <check level="error" class="this.does.not.Exist!" enabled="true"/>
</scalastyle>
```
It's error-prone. A project can keep thinking its configuration is right, while it's a simple typo in class name.

The downside of the solution is that it reports an error for each checked file. I believe it's strictly better than the current swallowing though.