### PR TITLE
Extend checks for correct braces/parentheses usage in for constructs

### DIFF
--- a/lib/scalastyle_config.xml
+++ b/lib/scalastyle_config.xml
@@ -157,6 +157,7 @@
  <check class="org.scalastyle.scalariform.BlockImportChecker" level="warning" enabled="false"></check>
  <check class="org.scalastyle.scalariform.ProcedureDeclarationChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.ForBraceChecker" level="warning" enabled="true"></check>
+ <check class="org.scalastyle.scalariform.ForLoopChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" level="warning" enabled="true"></check>
  <check class="org.scalastyle.scalariform.ScalaDocChecker" level="warning" enabled="false">
   <parameters>

--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -139,6 +139,7 @@
  <check level="warning" class="org.scalastyle.scalariform.BlockImportChecker" enabled="false"/>
  <check level="warning" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.ForLoopChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
   <parameters>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -301,6 +301,10 @@ for.brace.description = "Checks that braces are used in for comprehensions"
 for.brace.singleLineAllowed.label = "Allow parentheses for single-line for"
 for.brace.singleLineAllowed.description = "For with parentheses allowed if everything is on one line"
 
+for.loop.message = "Use parentheses in for loops"
+for.loop.label = "Use parentheses in for loops"
+for.loop.description = "Checks that parentheses are used in for loops"
+
 space.after.comment.start.message = "Insert a space after the start of the comment"
 space.after.comment.start.label = "Space after the start of the comment"
 space.after.comment.start.description = "Checks a space after the start of the comment."

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -166,6 +166,7 @@
             <parameter name="singleLineAllowed" type="boolean" default="false"/>
         </parameters>
     </checker>
+    <checker class="org.scalastyle.scalariform.ForLoopChecker" id="for.loop" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" id="space.after.comment.start" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning">
         <parameters>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -490,7 +490,7 @@ Note: If you intend to enable only if expressions in the format below, disable t
  <extra-description>
  The singleLineAllowed property allows for constructions of the type:
 
-    for (i &lt;- List(1,2,3)) println(i)
+    for (i &lt;- List(1,2,3)) yield i
  </extra-description>
  <example-configuration>
  <![CDATA[
@@ -502,6 +502,30 @@ Note: If you intend to enable only if expressions in the format below, disable t
  ]]>
  </example-configuration>
  </check>
+<check id="for.loop">
+<justification>
+   For-comprehensions which lack a yield clause is actually a loop rather than a functional comprehension and it is usually
+   more readable to string the generators together between parentheses rather than using the syntactically-confusing } { construct:
+
+   for (x &lt;- board.rows; y &lt;- board.files) {
+     printf("(%d, %d)", x, y)
+   }
+
+   is preferred to
+
+   for {
+     x &lt;- board.rows
+     y &lt;- board.files
+   } {
+     printf("(%d, %d)", x, y)
+   }
+</justification>
+<example-configuration>
+ <![CDATA[
+  <check level="warning" class="org.scalastyle.scalariform.ForLoopChecker" enabled="true" />
+]]>
+</example-configuration>
+</check>
 <check id="space.after.comment.start">
 <justification>
 To bring consistency with how comments should be formatted, leave a space right after the beginning of the comment.

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -294,6 +294,10 @@ for.brace.message = Use braces in for comprehensions
 for.brace.label = Use braces in for comprehensions
 for.brace.description = Checks that braces are used in for comprehensions
 
+for.loop.message = "Use parentheses in for loops"
+for.loop.label = "Use parentheses in for loops"
+for.loop.description = "Checks that parentheses are used in for loops"
+
 space.after.comment.start.message = Insert a single whitespace after the start of the comment and before end (incase it is a block comment).
 space.after.comment.start.label = Space after the start of the comment
 space.after.comment.start.description = Checks a space after the start and before the end of the comment.

--- a/src/main/scala/org/scalastyle/scalariform/ForBraceChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ForBraceChecker.scala
@@ -30,11 +30,15 @@ class ForBraceChecker extends CombinedChecker {
   final def verify(ast: CombinedAst): List[ScalastyleError] = {
     for {
       t <- VisitorHelper.getAll[ForExpr](ast.compilationUnit.immediateChildren.head)
-      if !validSingleLine(t, ast.lines) && (
+      if !loop(t) && !validSingleLine(t, ast.lines) && (
         Tokens.LPAREN == t.lParenOrBrace.tokenType ||
         Tokens.LPAREN == t.rParenOrBrace.tokenType
       )
     } yield PositionError(t.lParenOrBrace.offset)
+  }
+
+  private def loop(t: ForExpr) = {
+    t.yieldOption.isEmpty
   }
 
   private def validSingleLine(t: ForExpr, lines: Lines) = {

--- a/src/main/scala/org/scalastyle/scalariform/ForBraceChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ForBraceChecker.scala
@@ -30,15 +30,17 @@ class ForBraceChecker extends CombinedChecker {
   final def verify(ast: CombinedAst): List[ScalastyleError] = {
     for {
       t <- VisitorHelper.getAll[ForExpr](ast.compilationUnit.immediateChildren.head)
-      if !loop(t) && !validSingleLine(t, ast.lines) && (
+      if requireBraces(t, ast.lines) && (
         Tokens.LPAREN == t.lParenOrBrace.tokenType ||
         Tokens.LPAREN == t.rParenOrBrace.tokenType
       )
     } yield PositionError(t.lParenOrBrace.offset)
   }
 
-  private def loop(t: ForExpr) = {
-    t.yieldOption.isEmpty
+  private def requireBraces(t: ForExpr, lines: Lines) = {
+    t.yieldOption.nonEmpty && (
+      t.enumerators.tokens.exists(_.tokenType == Tokens.SEMI ) || !validSingleLine(t, lines)
+      )
   }
 
   private def validSingleLine(t: ForExpr, lines: Lines) = {

--- a/src/main/scala/org/scalastyle/scalariform/ForLoopChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ForLoopChecker.scala
@@ -1,0 +1,21 @@
+package org.scalastyle.scalariform
+
+import org.scalastyle.{CombinedAst, CombinedChecker, Lines, PositionError, ScalastyleError}
+
+import _root_.scalariform.lexer.Tokens
+import _root_.scalariform.parser.ForExpr
+
+class ForLoopChecker extends CombinedChecker {
+  val errorKey = "for.loop"
+
+  final def verify(ast: CombinedAst): List[ScalastyleError] = {
+    for {
+      t <- VisitorHelper.getAll[ForExpr](ast.compilationUnit.immediateChildren.head)
+      if isLoop(t) && !(
+        Tokens.LPAREN == t.lParenOrBrace.tokenType && Tokens.RPAREN == t.rParenOrBrace.tokenType
+      )
+    } yield PositionError(t.lParenOrBrace.offset)
+  }
+
+  private def isLoop(t: ForExpr) = t.yieldOption.isEmpty
+}

--- a/src/test/scala/org/scalastyle/scalariform/ForBraceCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ForBraceCheckerTest.scala
@@ -33,6 +33,9 @@ package foobar
 class Foobar {
   for ( t <- List(1,2,3)) yield t
   for { t <- List(1,2,3)} yield t
+  for ( t <- List(1,2,3)) {
+    printf("(%d)", t)
+  }
 }
 """
 

--- a/src/test/scala/org/scalastyle/scalariform/ForBraceCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ForBraceCheckerTest.scala
@@ -82,4 +82,17 @@ class Foobar {
 
     assertErrors(List(columnError(5, 6), columnError(6, 6), columnError(9, 6)), source)
   }
+
+  @Test def testMultipleExpressions(): Unit = {
+    val source = """
+package foobar
+
+class Foobar {
+  for ( t <- List(1,2,3); y <- List(2,4,6) ) yield (t, y)
+}
+"""
+
+    assertErrors(List(columnError(5, 6)),
+      source, Map("singleLineAllowed" -> "true"))
+  }
 }

--- a/src/test/scala/org/scalastyle/scalariform/ForLoopCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ForLoopCheckerTest.scala
@@ -1,0 +1,61 @@
+package org.scalastyle.scalariform
+
+import org.junit.Test
+import org.scalastyle.file.CheckerTest
+import org.scalatest.junit.AssertionsForJUnit
+
+// scalastyle:off magic.number
+
+class ForLoopCheckerTest extends AssertionsForJUnit with CheckerTest {
+  val key = "for.loop"
+  val classUnderTest = classOf[ForLoopChecker]
+
+  @Test def testOK(): Unit = {
+    val source =
+      """
+package foobar
+
+class Foobar {
+  for ( t <- List(1,2,3)) {
+    println(t)
+  }
+}
+"""
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testCurlyBracesUsed(): Unit = {
+    val source =
+      """
+package foobar
+
+class Foobar {
+   for {
+     p <- List(1,2,3)
+     t <- List(2,4,6)
+    } {
+      println(p + t)
+    }
+ }
+"""
+
+    assertErrors(List(columnError(5, 7)), source)
+  }
+
+  @Test def testIgnoresComprehension(): Unit = {
+    val source =
+      """
+package foobar
+
+class Foobar {
+   for {
+     p <- List(1,2,3)
+     t <- List(2,4,6)
+    } yield(p + t)
+ }
+"""
+
+    assertErrors(List(), source)
+  }
+}


### PR DESCRIPTION
* Require braces when multiple generators are used, like in
```scala
for (x <- board.rows; y <- board.files) yield (x, y)
```
* Add new check that requires for loops to use parentheses
* Ignore for loops in the ForBraces check

Fixes #112 and #142 