### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -25,8 +25,7 @@ import _root_.scalariform.lexer.Token
 import _root_.scalariform.parser.CompilationUnit
 import _root_.scalariform.parser.ScalaParser
 import scala.annotation.tailrec
-import scala.collection.JavaConversions.collectionAsScalaIterable
-import scala.collection.JavaConversions.seqAsJavaList
+import scala.collection.JavaConverters._
 import scala.io.Codec
 import scala.io.Source
 
@@ -65,7 +64,7 @@ class ScalastyleChecker[T <: FileSpec](classLoader: Option[ClassLoader] = None) 
   }
 
   def checkFilesAsJava(configuration: ScalastyleConfiguration, files: java.util.List[T]): java.util.List[Message[T]] = {
-    seqAsJavaList(privateCheckFiles(configuration, collectionAsScalaIterable(files)))
+    privateCheckFiles(configuration, files.asScala).asJava
   }
 
   private[this] def privateCheckFiles(configuration: ScalastyleConfiguration, files: Iterable[T]): Seq[Message[T]] = {

--- a/src/main/scala/org/scalastyle/Directory.scala
+++ b/src/main/scala/org/scalastyle/Directory.scala
@@ -19,8 +19,7 @@ package org.scalastyle
 import java.io.File
 import java.io.FileFilter
 
-import scala.collection.JavaConversions.collectionAsScalaIterable
-import scala.collection.JavaConversions.seqAsJavaList
+import scala.collection.JavaConverters._
 
 class Directory
 
@@ -34,7 +33,7 @@ object Directory {
   }
 
   def getFilesAsJava(encoding: Option[String], files: java.util.List[File]): java.util.List[FileSpec] = {
-    seqAsJavaList(privateGetFiles(encoding, collectionAsScalaIterable(files)))
+    privateGetFiles(encoding, files.asScala).asJava
   }
 
   def getFiles(encoding: Option[String], files: Iterable[File], excludedFiles: Seq[String] = Nil): List[FileSpec] = {

--- a/src/main/scala/org/scalastyle/Output.scala
+++ b/src/main/scala/org/scalastyle/Output.scala
@@ -18,7 +18,7 @@ package org.scalastyle
 
 import com.typesafe.config.Config
 
-import scala.collection.JavaConversions.collectionAsScalaIterable
+import scala.collection.JavaConverters._
 import scala.xml.Elem
 
 object Output {
@@ -38,7 +38,7 @@ trait Output[T <: FileSpec] {
 
   def output(messages: Seq[Message[T]]): OutputResult = privateOutput(messages)
 
-  def output(messages: java.util.List[Message[T]]): OutputResult = privateOutput(collectionAsScalaIterable(messages))
+  def output(messages: java.util.List[Message[T]]): OutputResult = privateOutput(messages.asScala)
 
   private[this] def privateOutput(messages: Iterable[Message[T]]): OutputResult = {
     messages.foreach(m => {
@@ -96,7 +96,7 @@ object XmlOutput {
                       save(config, new java.io.File(target), encoding, messages)
 
   def save[T <: FileSpec](config: Config, target: String, encoding: String, messages: java.util.List[Message[T]]): Unit =
-    save(config, new java.io.File(target), encoding, scala.collection.JavaConversions.collectionAsScalaIterable(messages))
+    save(config, new java.io.File(target), encoding, messages.asScala)
 
   def save[T <: FileSpec](config: Config, target: java.io.File, encoding: String, messages: Iterable[Message[T]]): Unit = {
     val width = 1000


### PR DESCRIPTION
JavaConversions deprecated since Scala 2.12. removed since Scala 2.13

https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/JavaConversions.scala#L59