### PR TITLE
Add regex param to HeaderMatchesChecker rule in the default config.

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -23,6 +23,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.]]></parameter>
+   <parameter name="regex"><![CDATA[false]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>


### PR DESCRIPTION
I added a missing `regex` parameter from the `HeaderMatchesChecker` rule in the default config.

This fixes #321.