### PR TITLE
FieldNamesChecker checks constructor params

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
@@ -243,6 +243,10 @@ class FieldNamesChecker extends ScalariformChecker {
       //destructuring start - val name(...
       case GeneralTokens(List(Token(VARID, _, _, _), Token(LPAREN, _, _, _))) if inValDef => Nil
 
+      // check constructor parameters
+      case Param(_, _, _, Token(tokenType, name, offset, _), _, _) if regex.findAllIn(name).isEmpty =>
+          List(PositionError(offset, List(regex.toString)))
+ 
       //actual name check
       case GeneralTokens(List(Token(VARID, name, offset, _))) if inValDef && regex.findAllIn(name).isEmpty =>
         List(PositionError(offset, List(regex.toString)))

--- a/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
@@ -452,4 +452,27 @@ class FieldNamesCheckerTest extends AssertionsForJUnit with CheckerTest {
     assertErrors(List(), source)
     assertErrors(List(columnError(2, 6, List("^[A-Z][A-Za-z0-9]*$"))), badSource)
   }
+  
+  @Test def testValidConstructorParamsOK(): Unit = {
+    val source =
+      """
+        |class foobar(val myArg1: String, var myArg2: Int)  {
+        |}
+      """.stripMargin
+
+    assertErrors(List(), source)
+  }
+
+  @Test def testInValidConstructorParamsKO(): Unit = {
+    val source =
+      """
+        |class foobar(val MyArg1: String, var MyArg2: Int)  {
+        |}
+      """.stripMargin
+
+    assertErrors(List(
+      columnError(2, 17, List("^[a-z][A-Za-z0-9]*$")),
+      columnError(2, 37, List("^[a-z][A-Za-z0-9]*$"))
+    ), source)
+  }
 }


### PR DESCRIPTION
In 0.9.0 the change in FieldNamesChecker stops checking constructor parameters; while 0.8.0 had that functionality.  