### PR TITLE
enable programmatic use of scalastyle

### DIFF
--- a/src/main/scala/org/scalastyle/Main.scala
+++ b/src/main/scala/org/scalastyle/Main.scala
@@ -105,7 +105,7 @@ object Main {
 
   private[this] def now(): Long = System.currentTimeMillis()
 
-  private[this] def execute(mc: MainConfig)(implicit codec: Codec): Boolean = {
+  def execute(mc: MainConfig)(implicit codec: Codec): Boolean = {
     val start = now()
     val configuration = ScalastyleConfiguration.readFromXml(mc.config.get)
     val cl = mc.externalJar.flatMap(j => Some(new URLClassLoader(Array(new java.io.File(j).toURI.toURL))))


### PR DESCRIPTION
right now it is not possible to integrate scalastyle in anything as library

our current problem is integrating scalastyle into Mill build tool

this change would enable us to call scalastyle programmatically and avoid problems with System.exit