### PR TITLE
PackageNamesChecker should allow only lowercase alphabets

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -50,7 +50,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+   <parameter name="regex"><![CDATA[^[a-z]+$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -39,7 +39,7 @@
     </checker>
     <checker class="org.scalastyle.scalariform.PackageNamesChecker" id="package.name" defaultLevel="warning">
         <parameters>
-            <parameter name="regex" type="string" default="^[a-z][A-Za-z]*$" />
+            <parameter name="regex" type="string" default="^[a-z]+$" />
         </parameters>
     </checker>
     <checker class="org.scalastyle.scalariform.PackageObjectNamesChecker" id="package.object.name" defaultLevel="warning">

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -693,7 +693,7 @@ To bring consistency with how comments should be formatted, leave a space right 
  <![CDATA[
     <check level="warning" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
       <parameters>
-        <parameter name="regex">^[a-z][A-Za-z]*$</parameter>
+        <parameter name="regex">^[a-z]+$</parameter>
       </parameters>
     </check>
  ]]>

--- a/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ClassNamesChecker.scala
@@ -81,7 +81,7 @@ class ObjectNamesChecker extends ScalariformChecker {
 }
 
 class PackageNamesChecker extends ScalariformChecker {
-  val DefaultRegex = "^[a-z][A-Za-z]*$"
+  val DefaultRegex = "^[a-z]+$"
   val errorKey = "package.name"
 
   def verify(ast: CompilationUnit): List[PositionError] = {

--- a/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ClassNamesCheckerTest.scala
@@ -113,7 +113,15 @@ package foobar
 package FooBar
 """
 
-    assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$"))), source)
+    assertErrors(List(columnError(2, 8, List("^[a-z]+$"))), source)
+  }
+
+  @Test def testSinglePartCamelCaseError(): Unit = {
+    val source = """
+package fooBar
+"""
+
+    assertErrors(List(columnError(2, 8, List("^[a-z]+$"))), source)
   }
 
   @Test def testMultiPartNoError(): Unit = {
@@ -129,7 +137,15 @@ package abc.foobar
 package abc.foo_bar
 """
 
-    assertErrors(List(columnError(2, 12, List("^[a-z][A-Za-z]*$"))), source)
+    assertErrors(List(columnError(2, 12, List("^[a-z]+$"))), source)
+  }
+
+  @Test def testMultiPartCamelCaseError(): Unit = {
+    val source = """
+package abc.fooBar
+"""
+
+    assertErrors(List(columnError(2, 12, List("^[a-z]+$"))), source)
   }
 
   @Test def testPackageObjectNoError(): Unit = {
@@ -157,7 +173,16 @@ package foo
 package Bar
 """
 
-    assertErrors(List(columnError(3, 8, List("^[a-z][A-Za-z]*$"))), source)
+    assertErrors(List(columnError(3, 8, List("^[a-z]+$"))), source)
+  }
+
+  @Test def testMultiLinePackageCamelCaseError(): Unit = {
+    val source = """
+package abc
+package fooBar
+"""
+
+    assertErrors(List(columnError(3, 8, List("^[a-z]+$"))), source)
   }
 
   @Test def testMultiLinePackageMultipleError(): Unit = {
@@ -166,7 +191,7 @@ package Foo
 package Bar
 """
 
-    assertErrors(List(columnError(2, 8, List("^[a-z][A-Za-z]*$")), columnError(3, 8, List("^[a-z][A-Za-z]*$"))), source)
+    assertErrors(List(columnError(2, 8, List("^[a-z]+$")), columnError(3, 8, List("^[a-z]+$"))), source)
   }
 
   @Test def testPackageAndPackageObjectNoError(): Unit = {


### PR DESCRIPTION
@matthewfarwell 
Fixes #310 

As per oracle officials docs, underscore is a valid token that can come after a word https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html

Per google's java style guide, even underscores are not allowed https://google.github.io/styleguide/javaguide.html#s5.2.1-package-names (going with this as the default behavior)

