### PR TITLE
Null check ignores when eq used instead of ==

### DIFF
--- a/src/main/scala/org/scalastyle/scalariform/NullChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/NullChecker.scala
@@ -35,7 +35,7 @@ class NullChecker extends ScalariformChecker {
     val it = for {
       (t, prev) <- ast.tokens.zip(dummyToken :: ast.tokens)
       if t.tokenType == Tokens.NULL
-      if !(allowNullChecks && prev.tokenType == Tokens.VARID && (prev.text == "==" || prev.text == "!="))
+      if !(allowNullChecks && prev.tokenType == Tokens.VARID && (prev.text == "==" || prev.text == "!=" || prev.text == "eq"))
     } yield {
       PositionError(t.offset)
     }

--- a/src/test/scala/org/scalastyle/scalariform/NullCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/NullCheckerTest.scala
@@ -87,4 +87,20 @@ object Foobar {
     assertErrors(List(columnError(6, 13), columnError(7, 18), columnError(10, 8), columnError(11, 13)), source,
       Map("allowNullChecks" -> "false"))
   }
+
+
+  @Test def testFour(): Unit = {
+    val source = """
+package foobar
+
+object Foobar {
+  def bar(s: String): Int = {
+    if (s eq null) 0
+    else 2
+  }
+}
+"""
+
+    assertErrors(List(), source)
+  }
 }


### PR DESCRIPTION
Ignore comparison when `eq` used instead of `==`